### PR TITLE
InitialLDの初期化漏れ

### DIFF
--- a/libs/DIparser.c
+++ b/libs/DIparser.c
@@ -1225,6 +1225,7 @@ NewEnv(
 	env->DBMasterPort = NULL;
 	env->DBMasterAuth = NULL;
 	env->DBMasterLogDBName = NULL;
+	env->InitialLD = NULL;
 
 	return	(env);
 }


### PR DESCRIPTION
InitialLDの初期化が漏れていると思います。
inital_ldが定義されていない場合に変なアドレスを指していました。
