### PR TITLE
sigactionを設定するのをやめ、適宜waitpidを実行する(SIG_IGN相当)

### DIFF
--- a/dblib/bytea.c
+++ b/dblib/bytea.c
@@ -10,7 +10,6 @@
 #include	<sys/types.h>
 #include	<sys/stat.h>
 #include	<unistd.h>
-#include	<signal.h>
 #include	<time.h>
 #include	<errno.h>
 

--- a/libs/pushevent.c
+++ b/libs/pushevent.c
@@ -32,7 +32,6 @@
 #include	<string.h>
 #include	<ctype.h>
 #include	<glib.h>
-#include	<signal.h>
 #include	<time.h>
 #include	<sys/time.h>
 


### PR DESCRIPTION
sigactionを設定してしまうとsystem()に影響があるため、
子プロセスの回収のみを実行する。