### PR TITLE
monblobコマンドにDB設定ファイル読み込みオプションを追加

### DIFF
--- a/aps/monblob.c
+++ b/aps/monblob.c
@@ -105,9 +105,9 @@ SetDBConfig()
 		memset(tmp+size,0,1);
 	}
 
-	elem = g_strsplit(buf,":",-1);
+	elem = g_strsplit_set(buf,":\n",-1);
 	g_free(buf);
-	for(i=0;i<elem[i]!=NULL;i++) {
+	for(i=0;elem[i]!=NULL;i++) {
 	}
 	if (i>=5) {
 		DB_Host = g_strdup(elem[0]);

--- a/aps/monblob.c
+++ b/aps/monblob.c
@@ -28,6 +28,7 @@
 #include	"debug.h"
 
 static	char			*Directory;
+static	char			*DBConfig;
 static	char			*ImportFile;
 static	Bool			List;
 static	Bool			Blob;
@@ -59,6 +60,8 @@ static	ARG_TABLE	option[] = {
 		"output file name"								},
 	{	"lifetype",	INTEGER,	TRUE,	(void*)&LifeType,
 		"lifetime type"									},
+	{	"dbconfig",	STRING,		TRUE,	(void*)&DBConfig,
+		"database connection config file" 				},
 	{	NULL,		0,			FALSE,	NULL,	NULL 	}
 };
 
@@ -72,6 +75,7 @@ SetDefault(void)
 	InfoID		= NULL;
 	CheckID		= NULL;
 	OutputFile	= NULL;
+	DBConfig	= NULL;
 	LifeType	= 1;
 	List		= FALSE;
 	Blob		= FALSE;
@@ -206,6 +210,14 @@ _blob_check_id(
 	}
 }
 
+static void
+SetDBConfig()
+{
+	if (DBConfig == NULL) {
+		return;
+	}
+}
+
 extern	int
 main(
 	int		argc,
@@ -239,6 +251,8 @@ main(
 
 	dbg = GetDBG_monsys();
 	dbg->dbt = NewNameHash();
+
+	SetDBConfig();
 
 	if (OpenDB(dbg) != MCP_OK ) {
 		exit(1);

--- a/aps/monblob.c
+++ b/aps/monblob.c
@@ -11,6 +11,7 @@
 #include	<sys/types.h>
 #include	<sys/stat.h>
 #include	<unistd.h>
+#include	<locale.h>
 #include	<signal.h>
 #include	<time.h>
 #include	<errno.h>

--- a/aps/monblob.c
+++ b/aps/monblob.c
@@ -86,10 +86,9 @@ SetDefault(void)
 static void
 SetDBConfig()
 {
-	char *buf,*tmp;
+	char *buf,*tmp,**elem;
 	size_t size;
-	GRegex *reg;
-	GMatchInfo *info;
+	int i;
 
 	if (DBConfig == NULL) {
 		return;
@@ -106,20 +105,20 @@ SetDBConfig()
 		memset(tmp+size,0,1);
 	}
 
-	reg = g_regex_new("(.*):(.*):(.*):(.*):(.*)",0,0,NULL);
-	g_regex_match(reg,buf,0,&info);
-	if (g_match_info_matches(info)) {
-		DB_Host = g_match_info_fetch(info,1);
-		DB_Port = g_match_info_fetch(info,2);
-		DB_Name = g_match_info_fetch(info,3);
-		DB_User = g_match_info_fetch(info,4);
-		DB_Pass = g_match_info_fetch(info,5);
+	elem = g_strsplit(buf,":",-1);
+	g_free(buf);
+	for(i=0;i<elem[i]!=NULL;i++) {
+	}
+	if (i>=5) {
+		DB_Host = g_strdup(elem[0]);
+		DB_Port = g_strdup(elem[1]);
+		DB_Name = g_strdup(elem[2]);
+		DB_User = g_strdup(elem[3]);
+		DB_Pass = g_strdup(elem[4]);
 	} else {
 		Warning("invalid DBConfig format. <Host>:<Port>:<Database>:<User>:<Password>");
 	}
-	g_match_info_free(info);
-	g_regex_unref(reg);
-	g_free(buf);
+	g_strfreev(elem);
 }
 
 static	void

--- a/aps/monblob.c
+++ b/aps/monblob.c
@@ -213,9 +213,40 @@ _blob_check_id(
 static void
 SetDBConfig()
 {
+	char *buf,*tmp;
+	size_t size;
+	GRegex *reg;
+	GMatchInfo *info;
+
 	if (DBConfig == NULL) {
 		return;
 	}
+	if (!g_file_get_contents(DBConfig,&buf,&size,NULL)) {
+		Error("can not read %s",DBConfig);
+	}
+
+	tmp = realloc(buf,size+1);
+	if (tmp == NULL) {
+		Error("realloc(3) failure");
+	} else {
+		buf = tmp;
+		memset(tmp+size,0,1);
+	}
+
+	reg = g_regex_new("(.*):(.*):(.*):(.*):(.*)",0,0,NULL);
+	g_regex_match(reg,buf,0,&info);
+	if (g_match_info_matches(info)) {
+		DB_Host = g_match_info_fetch(info,1);
+		DB_Port = g_match_info_fetch(info,2);
+		DB_Name = g_match_info_fetch(info,3);
+		DB_User = g_match_info_fetch(info,4);
+		DB_Pass = g_match_info_fetch(info,5);
+	} else {
+		Warning("invalid DBConfig format. <Host>:<Port>:<Database>:<User>:<Password>");
+	}
+	g_match_info_free(info);
+	g_regex_unref(reg);
+	g_free(buf);
 }
 
 extern	int
@@ -228,6 +259,7 @@ main(
 	Bool rc;
 	MonObjectType oid;
 
+	setlocale(LC_CTYPE,"ja_JP.UTF-8");
 	SetDefault();
 	GetOption(option,argc,argv,NULL);
 	InitSystem();


### PR DESCRIPTION
DB設定ファイルのフォーマットはPostgreSQLのpgpassファイルとほぼ同じ(1行のみでコメント等はなし)。

```
<DBホスト>:<DBポート>:<DBユーザ>:<DBパスワード>
```

DB設定の反映は MONDB_HOST などの環境変数ではなく、dblib/dbgroup.hのグローバル変数DB_HOSTなどの設定で行っている。