### PR TITLE
Use pr set pdeathsig

### DIFF
--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -34,6 +34,7 @@
 #include	<string.h>
 #include	<libgen.h>
 #include    <sys/socket.h>
+#include	<sys/prctl.h>
 #include	<pthread.h>
 #include	<glib.h>
 
@@ -393,6 +394,8 @@ main(
 	if (sigaction(SIGUSR2, &sa, NULL) != 0) {
 		Error("sigaction(2) failure");
 	}
+
+	prctl(PR_SET_PDEATHSIG, SIGHUP);
 
 	stdout_path = getenv("APS_DEBUG_STDOUT_PATH");
 	if (stdout_path != NULL) {

--- a/glserver/glserver.c
+++ b/glserver/glserver.c
@@ -35,6 +35,7 @@
 #include	<sys/time.h>
 #include	<sys/wait.h>
 #include	<sys/stat.h>
+#include	<sys/prctl.h>
 #include	<unistd.h>
 #include	<glib.h>
 #include	<signal.h>
@@ -207,6 +208,8 @@ main(
 	if (sigaction(SIGPIPE, &sa, NULL) != 0) {
 		Error("sigaction(2) failure");
 	}
+
+	prctl(PR_SET_PDEATHSIG, SIGHUP);
 
 	SetDefault();
 	(void)GetOption(option,argc,argv,NULL);

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -896,20 +896,6 @@ LEAVE_FUNC;
 }
 
 static	void
-KillAll()
-{
-	int		i;
-	Process	*proc;
-
-ENTER_FUNC;
-	for(i = 0; i < g_list_length(ProcessList); i++) {
-		proc = g_list_nth_data(ProcessList,i);
-		kill(proc->pid,SIGKILL);
-	}
-LEAVE_FUNC;
-}
-
-static	void
 StartSetup()
 {
 	pid_t	pid;
@@ -965,15 +951,10 @@ static	void
 StopServers(void)
 {
 ENTER_FUNC;
-#if 0
 	KillProcess(PTYPE_GLS,SIGHUP);
-#else 
-	system("/usr/bin/killall -HUP glserver");
-#endif
 	KillProcess(PTYPE_APS,SIGHUP);
 	KillProcess((PTYPE_WFC | PTYPE_RED | PTYPE_LOG | PTYPE_MST),SIGHUP);
 	sleep(1);
-	KillAll();
 LEAVE_FUNC;
 }
 

--- a/wfc/wfc.c
+++ b/wfc/wfc.c
@@ -41,6 +41,7 @@
 #include	<sys/time.h>
 #include	<sys/wait.h>
 #include	<sys/stat.h>		/*	for	mknod	*/
+#include	<sys/prctl.h>
 #include	<unistd.h>
 #include	<glib.h>
 #include	<pthread.h>
@@ -386,6 +387,8 @@ main(
 	if (stderr_path != NULL) {
 		freopen(stderr_path,"w",stderr);
 	}
+
+	prctl(PR_SET_PDEATHSIG, SIGHUP);
 
 	InitMessage("wfc",NULL);
 ENTER_FUNC;


### PR DESCRIPTION
* glserver,aps,wfcにprctl(PR_SET_PDEATHSIG)をセット
* monitorでのkillallをやめる

手元でパッケージを作って10数回日レセの再起動(/etc/init.d/jma-receiptのkillallも削除して)を行い、1度だけglserverのプロセスが残るのを確認したが、その後再現できず。sudo service jma-receipt restart実行中に再度restartかけたせいかも。

glserverのプロセスが残るとport=8000をopenできず再起動のglserverが起動できずにmonitorがglserverの起動を実行し続けてしまう。

/etc/init.d/jma-receipt中のkillallを残しておけばとりあえず問題は発生しないと思われる。