### PR TITLE
libs/net.c: 直接メンバを参照しているところをカプセル化

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,14 @@ AC_ARG_WITH(ssl,
 		AC_SUBST(SSL_LIBS) 
 		AC_SUBST(SSL_CFLAGS) 
 		AC_DEFINE(USE_SSL,1,"")
+		PKG_CHECK_MODULES(SSL, libssl >= 1.1.0,
+			[],
+			[
+				PKG_CHECK_MODULES(SSL, libssl < 1.1.0,
+					[AC_DEFINE(SSL_1_0_0,1,"")]
+				)
+			]
+		)
 		enable_ssl="yes"
 	fi
 ])		

--- a/libs/net.c
+++ b/libs/net.c
@@ -71,6 +71,33 @@ static	Bool		LoadEnginePKCS11(SSL_CTX *ctx, ENGINE **e, const char *pkcs11, cons
 #endif	//	USE_PKCS11
 #endif	//	USE_SSL
 
+#ifdef SSL_1_0_0
+int ASN1_STRING_length(const ASN1_STRING *x)
+{
+    return x->length;
+}
+
+const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
+{
+    return x->data;
+}
+
+int X509_STORE_CTX_get_error(X509_STORE_CTX *ctx)
+{
+    return ctx->error;
+}
+
+X509 *X509_STORE_CTX_get_current_cert(X509_STORE_CTX *ctx)
+{
+    return ctx->current_cert;
+}
+
+X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *ctx)
+{
+    return ctx->cert_store;
+}
+#endif  //  SSL_1_0_0
+
 static	Bool
 _Flush(
 	NETFILE	*fp)


### PR DESCRIPTION
Ubuntu18.04 で OpenSSL が 1.0系から1.1系にアップデートされたことに伴ってコンパイルできなくなっていた箇所の変更です。
下記リンクの Compatibility_Layer に従って、メンバへのアクセス部分をマクロに置き換えています。
https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes#Compatibility_Layer