### PR TITLE
ステータス通知のポップアップが何度もでるのでトップのウィンドウ以外はウィジェット更新しないよう修正、CURLのデフォルトタイムアウト時間を…

### DIFF
--- a/glclient/action.c
+++ b/glclient/action.c
@@ -1178,8 +1178,8 @@ static void UpdateWindow(json_object *w, int idx) {
     if (child == NULL || is_error(child)) {
       Error("invalid json part:screeen_data");
     }
-    UpdateWidget(GetWidgetByLongName(wname), wdata->tmpl);
     if (!strcmp(wname, FOCUSEDWINDOW(Session))) {
+      UpdateWidget(GetWidgetByLongName(wname), wdata->tmpl);
       ShowWindow(wname);
     }
     ResetTimers((char *)wname);

--- a/glclient/protocol.c
+++ b/glclient/protocol.c
@@ -928,6 +928,8 @@ void GLP_SetSSL(GLProtocol *ctx, const char *cert, const char *key,
 }
 #endif
 
+#define DEFAULT_CURL_TIMEOUT_SEC (300)
+
 static CURL *InitCURL(const char *user, const char *pass) {
   CURL *Curl;
   char userpass[1024];
@@ -949,7 +951,7 @@ static CURL *InitCURL(const char *user, const char *pass) {
   curl_easy_setopt(Curl, CURLOPT_NOPROXY, "*");
   curl_easy_setopt(Curl, CURLOPT_TCP_KEEPALIVE, 0L);
 
-  long to = 30;
+  long to = DEFAULT_CURL_TIMEOUT_SEC;
   char *_to;
 
   _to = getenv("GLCLIENT_CURL_TIMEOUT_SEC");


### PR DESCRIPTION
…300秒に変更