### PR TITLE
51946753 BlobCacheFileNameをCacheDir/%p,valueにするようにした

### DIFF
--- a/glserver/blobcache.c
+++ b/glserver/blobcache.c
@@ -55,11 +55,7 @@ BlobCacheFileName(
 	char	buf[SIZE_BUFF];
 
 	if		(  ValueObjectFile(value)  ==  NULL  ) {
-		if		(  IS_OBJECT_NULL(ValueObjectId(value))  ) {
-			sprintf(buf,"%s/%p",CacheDir, value);
-		} else {
-			sprintf(buf,"%s/%s",CacheDir,ValueToString(value,NULL));
-		}
+		sprintf(buf,"%s/%p",CacheDir, value);
 		ValueObjectFile(value) = StrDup(buf);
 	}
 	return	(ValueObjectFile(value));

--- a/glserver/blobcache.c
+++ b/glserver/blobcache.c
@@ -52,10 +52,11 @@ extern	char	*
 BlobCacheFileName(
 	ValueStruct	*value)
 {
-	char	buf[SIZE_BUFF];
+	char	buf[SIZE_BUFF+1];
 
 	if		(  ValueObjectFile(value)  ==  NULL  ) {
-		sprintf(buf,"%s/%p",CacheDir, value);
+		memset(buf,0,SIZE_BUFF+1);
+		snprintf(buf,SIZE_BUFF,"%s/%p",CacheDir, value);
 		ValueObjectFile(value) = StrDup(buf);
 	}
 	return	(ValueObjectFile(value));


### PR DESCRIPTION
ValueToStringの結果をファイル名に使っていたので、クライアントから不正というかズレたイベントデータを投げられるとまずいケースがあった。
不正なイベントデータの検出は受信した値を設定するValueStructの型とクライアントから送信された型をチェックすることで回避できる。しかし、現状のアプリで意識して、あるいは意識せずにウィジェット型と画面定義体型がズレているケースがありうるのでとりあえずそちらは見送った。

修正したglsererで以下を確認

1. プレビュー表示に問題ないこと
2. 薬剤情報画面から画像ファイルをサーバに登録可能なこと
3. 1.2.の操作でsyslogにエラーが発生していないこと