### PR TITLE
セッションのaccess_timeの更新が漏れていたのを修正

### DIFF
--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -218,10 +218,13 @@ static void DeregisterSession(SessionData *data) {
 static void UpdateSession(SessionData *data) {
   SessionCtrl *ctrl;
   ENTER_FUNC;
+
+  gettimeofday(&(data->access_time), NULL);
   ctrl = NewSessionCtrl(SESSION_CONTROL_UPDATE);
   ctrl->session = data;
   ctrl = ExecSessionCtrl(ctrl);
   FreeSessionCtrl(ctrl);
+
   LEAVE_FUNC;
 }
 


### PR DESCRIPTION
セッション情報にcreate_timeとaccess_timeがあってwfc/termthread.cで更新してセッション情報テーブルに格納している。moninfoコマンド等でセッション情報テーブルを参照してユーザ一覧等を返しているが、5.0.0リリース時にaccess_timeの更新が漏れた模様。