### PR TITLE
monitorリスタート時にkillに失敗した場合にkillallするのをやめる

### DIFF
--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -627,7 +627,6 @@ static void InitServers(void) {
 static void KillProcess(unsigned char type, int sig) {
   int i;
   Process *proc;
-  char command[1024];
 
   ENTER_FUNC;
   for (i = 0; i < g_list_length(ProcessList); i++) {
@@ -635,10 +634,7 @@ static void KillProcess(unsigned char type, int sig) {
     if ((proc->type & type) != 0) {
       dbgprintf("kill -%d %d\n", sig, proc->pid);
       if (kill(proc->pid, sig) == -1) {
-        sprintf(command, "killall -HUP %s", proc->argv[0]);
-        system(command);
         Message("kill(2) failure: %s", strerror(errno));
-        Message("%s", command);
       }
       proc->state = STATE_STOP;
     }


### PR DESCRIPTION
monitorはwfc,aps,glserverのプロセスを起動し、監視するプロセスである。
monitorにSIGHUPを送ると子プロセスを全部killして再起動する。
その際に子プロセスが既に落ちていたりしてkillに失敗するとkillallするようになっていたがこれを止める。

日レセオンプレ環境で、理由は不明だがmonitorが2つ同時に起動することがあり、プログラム更新時にそれぞれ再起動を行い、片方がkillに失敗してkillallすることで他方の子プロセスを殺してしまうことがあった。そもそも管理していない子プロセスを殺すのは筋が悪い。