### PR TITLE
dbg->serverの初期化が不十分だった、GetDB_User等の返り値が間違っていた

### DIFF
--- a/dblib/PostgreSQLutils.c
+++ b/dblib/PostgreSQLutils.c
@@ -55,6 +55,11 @@ extern PGconn *pg_connect(DBG_Struct *dbg) {
   if (dbg->dbstatus == DB_STATUS_CONNECT) {
     /* database is already connected. */
     conn = PGCONN(dbg);
+  } else {
+    if ((conn = PgConnect(dbg)) != NULL) {
+      dbg->conn = (void*)conn;
+      dbg->dbstatus = DB_STATUS_CONNECT;
+    }
   }
   return conn;
 }
@@ -69,7 +74,6 @@ extern void pg_disconnect(DBG_Struct *dbg) {
 extern Bool pg_trans_begin(DBG_Struct *dbg) {
   Bool ret = FALSE;
   PGconn *conn = NULL;
-
   conn = pg_connect(dbg);
   ret = db_command(conn, "BEGIN;");
   return ret;

--- a/dblib/dbgroup.c
+++ b/dblib/dbgroup.c
@@ -415,14 +415,15 @@ extern int GetDB_PortMode(DBG_Struct *dbg) {
 }
 
 extern char *GetDB_DBname(DBG_Struct *dbg) {
+  char *name = NULL;
   if (DB_Name != NULL) {
-    return DB_Name;
+    name = DB_Name;
+  } else {
+    if ((name = GetMONDB_ENV(dbg, "NAME")) == NULL) {
+      name = dbg->server->dbname;
+    }
   }
-  char *name = GetMONDB_ENV(dbg, "NAME");
-  if (name != NULL) {
-    return name;
-  }
-  return dbg->server->dbname;
+  return (name);
 }
 
 extern char *GetDB_User(DBG_Struct *dbg) {
@@ -430,7 +431,9 @@ extern char *GetDB_User(DBG_Struct *dbg) {
   if (DB_User != NULL) {
     user = DB_User;
   } else {
-    user = GetMONDB_ENV(dbg, "USER");
+    if ((user = GetMONDB_ENV(dbg, "USER")) == NULL) {
+      user = dbg->server->user;
+    }
   }
   return (user);
 }
@@ -440,7 +443,9 @@ extern char *GetDB_Pass(DBG_Struct *dbg) {
   if (DB_Pass != NULL) {
     pass = DB_Pass;
   } else {
-    pass = GetMONDB_ENV(dbg, "PASS");
+    if ((pass = GetMONDB_ENV(dbg, "PASS")) == NULL) {
+      pass = dbg->server->pass;
+    }
   }
   return (pass);
 }
@@ -458,31 +463,41 @@ extern char *GetDB_Crypt(DBG_Struct *dbg) {
 
 extern char *GetDB_Sslmode(DBG_Struct *dbg) {
   char *sslmode = NULL;
-  sslmode = GetMONDB_ENV(dbg, "SSLMODE");
+  if ((sslmode = GetMONDB_ENV(dbg, "SSLMODE")) == NULL) {
+    sslmode = dbg->server->sslmode;
+  }
   return (sslmode);
 }
 
 extern char *GetDB_Sslcert(DBG_Struct *dbg) {
   char *sslcert = NULL;
-  sslcert = GetMONDB_ENV(dbg, "SSLCERT");
+  if ((sslcert = GetMONDB_ENV(dbg, "SSLCERT")) == NULL) {
+    sslcert = dbg->server->sslcert;
+  }
   return (sslcert);
 }
 
 extern char *GetDB_Sslkey(DBG_Struct *dbg) {
   char *sslkey = NULL;
-  sslkey = GetMONDB_ENV(dbg, "SSLKEY");
+  if ((sslkey = GetMONDB_ENV(dbg, "SSLKEY")) == NULL) {
+    sslkey = dbg->server->sslkey;
+  }
   return (sslkey);
 }
 
 extern char *GetDB_Sslrootcert(DBG_Struct *dbg) {
   char *sslrootcert = NULL;
-  sslrootcert = GetMONDB_ENV(dbg, "SSLROOTCERT");
+  if ((sslrootcert = GetMONDB_ENV(dbg, "SSLROOTCERT")) == NULL) {
+    sslrootcert = dbg->server->sslrootcert;
+  }
   return (sslrootcert);
 }
 
 extern char *GetDB_Sslcrl(DBG_Struct *dbg) {
   char *sslcrl = NULL;
-  sslcrl = GetMONDB_ENV(dbg, "SSLCRL");
+  if ((sslcrl = GetMONDB_ENV(dbg, "SSLCRL")) == NULL) {
+    sslcrl = dbg->server->sslcrl;
+  }
   return (sslcrl);
 }
 

--- a/libs/DIparser.c
+++ b/libs/DIparser.c
@@ -629,7 +629,6 @@ extern DBG_Struct *NewDBG_Struct(char *name) {
   dbg->id = 0;
   dbg->type = NULL;
   dbg->func = NULL;
-  dbg->server = New(DB_Server);
   dbg->transaction_id = NULL;
   dbg->file = NULL;
   dbg->sumcheck = 1;
@@ -649,6 +648,17 @@ extern DBG_Struct *NewDBG_Struct(char *name) {
   dbg->errcount = 0;
   dbg->dbstatus = DB_STATUS_NOCONNECT;
   dbg->conn = NULL;
+
+  dbg->server = New(DB_Server);
+  dbg->server->port = NULL;
+  dbg->server->dbname = NULL;
+  dbg->server->user = NULL;
+  dbg->server->pass = NULL;
+  dbg->server->sslmode = NULL;
+  dbg->server->sslcert = NULL;
+  dbg->server->sslkey = NULL;
+  dbg->server->sslrootcert = NULL;
+  dbg->server->sslcrl = NULL;
 
   if ((env = getenv("MONDB_LOCALE")) == NULL) {
     dbg->coding = DB_LOCALE;

--- a/tools/dbsync.c
+++ b/tools/dbsync.c
@@ -237,7 +237,7 @@ static char table_relkind(TableList *table_list, int num) {
 }
 
 static TableList *table_check(DBG_Struct *master_dbg, DBG_Struct *slave_dbg) {
-  int i, m, s, cmp, rcmp;
+  int i, m, s, cmp, rcmp, cnt;
   TableList *master_list, *slave_list, *ng_list;
 
   pg_trans_begin(master_dbg);
@@ -247,7 +247,12 @@ static TableList *table_check(DBG_Struct *master_dbg, DBG_Struct *slave_dbg) {
   pg_trans_commit(master_dbg);
   pg_trans_commit(slave_dbg);
 
-  ng_list = NewTableList(master_list->count + slave_list->count);
+  cnt = master_list->count + slave_list->count;
+  if (cnt <= 0) {
+    Error("master_list->count + slave_list->count <= 0; empty dbs?");
+  }
+
+  ng_list = NewTableList(cnt);
   m = s = 0;
   for (i = 0; (master_list->count > m) || (slave_list->count > s); i++) {
     cmp = strcmp(table_name(master_list, m), table_name(slave_list, s));


### PR DESCRIPTION
* 日レセ用DBレプリケーションツールのdbredirectorがうまく動作していなかった
* DBの主従の動機をとるツール dbsyncが以下のようにSegVしていた

```
2018/12/17/13:04:42 P:dbsync.c:419:Start [""] -> ["log"]
connection pointer is NULL

connection pointer is NULL

connection pointer is NULL

connection pointer is NULL

/usr/lib/jma-receipt/bin/jma-dbsync.sh: 15 行:  5138 Segmentation fault      (コアダンプ) $DBSYNC -dir ${LDDEFDIR}/directory $*
```