### PR TITLE
[ginbeeメモリ削減]画面定義体とDB定義体の逐次確保、解放

### DIFF
--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -305,6 +305,7 @@ retry:
     MemSaveEnd(node);
   }
   MessageLogPrintf("exiting APS (%s)", ThisLD->name);
+  MemSaveEnd(node);
   FinishSession(node);
 quit:
   if (fpWFC != NULL) {

--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -91,7 +91,7 @@ static void InitSystem(char *name) {
     }
     env = getenv("MON_SCR_REC_MEM_SAVE");
     if (env != NULL) {
-      SetScrRecMemSave(env[0]=='1');
+      SetScrRecMemSave(env[0] == '1');
     }
   }
   SetUpDirectory(Directory, name, "", "", P_ALL);

--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -42,6 +42,7 @@
 #include "libmondai.h"
 #include "RecParser.h"
 #include "DDparser.h"
+#include "DBparser.h"
 #include "enum.h"
 #include "dirs.h"
 #include "socket.h"
@@ -199,7 +200,7 @@ static void MemSaveEnd(ProcessNode *node) {
   }
   if (GetDBRecMemSave()) {
     for(i=0;i<ThisLD->cDB;i++) {
-      FreeRecordValue(ThisLD->db[i]);
+      DB_Parser_Lazy_Free(ThisLD->db[i]);
     }
   }
   ed = GetNowTime();

--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -178,8 +178,11 @@ static void SetMCPEnv(ValueStruct *val) {
 
 static void MemSaveBegin(ProcessNode *node) {
   int i;
+#ifdef MON_MEM_SAVE_TRACE
   unsigned long st,ed;
   st = GetNowTime();
+  PrintRSS("MemSaveBegin1");
+#endif
   if (GetScrRecMemSave()) {
     for(i=0;i<node->cWindow;i++) {
       if (node->scrrec[i] == NULL) {
@@ -187,14 +190,20 @@ static void MemSaveBegin(ProcessNode *node) {
       }
     }
   }
+#ifdef MON_MEM_SAVE_TRACE
+  PrintRSS("MemSaveBegin2");
   ed = GetNowTime();
-  TimerPrintf(st, ed, "MemSaveBegin");
+  fprintf(stderr,"MemSaveBegin (%6ld)ms\n",ed-st);
+#endif
 }
 
 static void MemSaveEnd(ProcessNode *node) {
   int i;
+#ifdef MON_MEM_SAVE_TRACE
   unsigned long st,ed;
   st = GetNowTime();
+  PrintRSS("MemSaveEnd1");
+#endif
   if (GetScrRecMemSave()) {
     for(i=0;i<node->cWindow;i++) {
       if (node->scrrec[i] != NULL) {
@@ -211,8 +220,11 @@ static void MemSaveEnd(ProcessNode *node) {
       }
     }
   }
+#ifdef MON_MEM_SAVE_TRACE
+  PrintRSS("MemSaveEnd2");
   ed = GetNowTime();
-  TimerPrintf(st, ed, "MemSaveEnd");
+  fprintf(stderr,"MemSaveEnd (%6ld)ms\n",ed-st);
+#endif
 }
 
 static int ExecuteServer(void) {

--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -107,7 +107,7 @@ static void InitSystem(char *name) {
   ThisDBD = NULL;
 
   InitiateHandler();
-  ThisDB = ThisLD->db;
+  DBGroup_Init(ThisLD->db, ThisLD->dbmeta);
   DB_Table = ThisLD->DB_Table;
   TextSize = ThisLD->textsize;
   if (ThisEnv->mcprec != NULL) {
@@ -182,7 +182,9 @@ static void MemSaveBegin(ProcessNode *node) {
   st = GetNowTime();
   if (GetScrRecMemSave()) {
     for(i=0;i<node->cWindow;i++) {
-      MallocRecordValue(node->scrrec[i]);
+      if (node->scrrec[i] == NULL) {
+        node->scrrec[i] = ReadRecordDefine(ThisLD->windowsmeta[i]->name,FALSE);
+      }
     }
   }
   ed = GetNowTime();
@@ -195,12 +197,18 @@ static void MemSaveEnd(ProcessNode *node) {
   st = GetNowTime();
   if (GetScrRecMemSave()) {
     for(i=0;i<node->cWindow;i++) {
-      FreeRecordValue(node->scrrec[i]);
+      if (node->scrrec[i] != NULL) {
+        FreeRecordStruct(node->scrrec[i]);
+        node->scrrec[i] = NULL;
+      }
     }
   }
   if (GetDBRecMemSave()) {
     for(i=0;i<ThisLD->cDB;i++) {
-      DB_Parser_Lazy_Free(ThisLD->db[i]);
+      if (ThisLD->db[i] != NULL) {
+        FreeRecordStruct(ThisLD->db[i]);
+        ThisLD->db[i] = NULL;
+      }
     }
   }
   ed = GetNowTime();

--- a/aps/dbstub_main.c
+++ b/aps/dbstub_main.c
@@ -74,7 +74,7 @@ extern void InitSystem(char *name) {
   ThisLD = NULL;
   ThisDBD = NULL;
   InitiateBatchHandler();
-  ThisDB = ThisBD->db;
+  DBGroup_Init(ThisBD->db,NULL);
   DB_Table = ThisBD->DB_Table;
   TextSize = ThisBD->textsize;
   if (ThisEnv->mcprec != NULL) {

--- a/dblib/PushEvent.c
+++ b/dblib/PushEvent.c
@@ -60,7 +60,9 @@ static ValueStruct *_PushEvent(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
     Warning("PushData is wrong");
     return NULL;
   }
-
+  if (PushData == NULL) {
+    PushData = json_object_new_array();
+  }
   obj = push_event_conv_value(args);
   if (CheckJSONObject(obj, json_type_object)) {
     json_object_array_add(PushData, obj);
@@ -102,6 +104,8 @@ extern ValueStruct *_PushEventCommit(DBG_Struct *dbg, DBCOMM_CTRL *ctrl) {
     if (!json_object_object_get_ex(obj, "event", &event)) {
       continue;
     }
+    /* add ref count */
+    json_object_get(body);
     if (!push_event_via_json(
             mondbg, (const char *)json_object_get_string(event), body)) {
       ctrl->rc = MCP_BAD_OTHER;

--- a/dblib/dbgroup.c
+++ b/dblib/dbgroup.c
@@ -43,6 +43,7 @@
 #include "libmondai.h"
 #include "directory.h"
 #include "DDparser.h"
+#include "DBparser.h"
 #include "dbgroup.h"
 #include "debug.h"
 
@@ -578,11 +579,13 @@ extern Bool SetDBCTRLValue(DBCOMM_CTRL *ctrl, char *pname) {
     Warning("path name not set.\n");
     return FALSE;
   }
+fprintf(stderr,"ctrl->rec:%p name:%s value:%p RecordDB:%p\n",ctrl->rec,ctrl->rec->name,ctrl->rec->value,RecordDB(ctrl->rec));
   strncpy(ctrl->pname, pname, SIZE_NAME);
   if (ctrl->rec == NULL) {
     return FALSE;
   }
   value = ctrl->rec->value;
+fprintf(stderr,"RecordDB(ctrl->rec)->paths:%p\n",RecordDB(ctrl->rec)->paths);
   if ((pno = (int)(long)g_hash_table_lookup(RecordDB(ctrl->rec)->paths,
                                             pname)) != 0) {
     pno--;
@@ -616,7 +619,15 @@ extern Bool SetDBCTRLRecord(DBCOMM_CTRL *ctrl, char *rname) {
     ctrl->rno = rno - 1;
     ctrl->rec = ThisDB[ctrl->rno];
     if (GetDBRecMemSave()) {
-      MallocRecordValue(ctrl->rec);
+fprintf(stderr,"org ctrl->rec:%p\n",ctrl->rec);
+      RecordStruct *real;
+      real = DB_Parser_Lazy_Real(ctrl->rec);
+fprintf(stderr,"real:%p\n",real);
+fprintf(stderr,"RecordDB(real):%p\n",RecordDB(real));
+fprintf(stderr,"dbg:%p\n",RecordDB(real)->dbg);
+      RecordDB(real)->dbg = RecordDB(ctrl->rec)->dbg;
+      ctrl->rec = real;
+fprintf(stderr,"new ctrl->rec:%p\n",ctrl->rec);
     }
     rc = TRUE;
   } else {

--- a/dblib/dbgroup.c
+++ b/dblib/dbgroup.c
@@ -614,7 +614,10 @@ extern Bool SetDBCTRLRecord(DBCOMM_CTRL *ctrl, char *rname) {
   ctrl->fDBOperation = FALSE;
   if ((rno = (int)(long)g_hash_table_lookup(DB_Table, ctrl->rname)) != 0) {
     ctrl->rno = rno - 1;
-    ctrl->rec = ThisDB[rno - 1];
+    ctrl->rec = ThisDB[ctrl->rno];
+    if (GetDBRecMemSave()) {
+      MallocRecordValue(ctrl->rec);
+    }
     rc = TRUE;
   } else {
     Warning("The table name of [%s] is not found.\n", rname);

--- a/dblib/dbgroup.h
+++ b/dblib/dbgroup.h
@@ -30,6 +30,8 @@
 #define REDIRECT_LOCK_TABLE "montsuqi_redirector_lock_table"
 #define MONDB "mondb_"
 
+extern void DBGroup_Init(RecordStruct **db,RecordStructMeta **meta);
+
 extern void InitializeCTRL(DBCOMM_CTRL *ctrl);
 
 extern int OpenRedirectDB(DBG_Struct *dbg);
@@ -75,6 +77,7 @@ extern void SetDBConfig(const char *config);
 #endif
 
 GLOBAL RecordStruct **ThisDB;
+GLOBAL RecordStructMeta **ThisDBMeta;
 
 GLOBAL char *DB_Host;
 GLOBAL char *DB_Port;

--- a/dblib/monpushevent.c
+++ b/dblib/monpushevent.c
@@ -253,25 +253,25 @@ static gboolean AMQPSend(const char *event, const char *msg) {
   socket = amqp_tcp_socket_new(conn);
   if (!socket) {
     fprintf(stderr, "creating TCP socket\n");
-    return FALSE;
+    goto AMQP_CONN_ERROR;
   }
   status = amqp_socket_open(socket, hostname, port);
   if (status) {
     fprintf(stderr, "opening TCP socket\n");
-    return FALSE;
+    goto AMQP_CONN_ERROR;
   }
 
   reply =
       amqp_login(conn, "/", 0, 131072, 0, AMQP_SASL_METHOD_PLAIN, user, pass);
   if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
     fprintf(stderr, "amqp_login\n");
-    return FALSE;
+    goto AMQP_CONN_ERROR;
   }
   amqp_channel_open(conn, 1);
   reply = amqp_get_rpc_reply(conn);
   if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
     fprintf(stderr, "amqp_get_rpc_reply\n");
-    return FALSE;
+    goto AMQP_CONN_ERROR;
   }
   {
     if (getenv("PUSHEVENT_LOGGING")) {
@@ -286,7 +286,7 @@ static gboolean AMQPSend(const char *event, const char *msg) {
                            amqp_cstring_bytes(msg));
     if (x < 0) {
       fprintf(stderr, "amqp_basic_publish\n");
-      return FALSE;
+      goto AMQP_CONN_ERROR;
     }
   }
   g_free(routingkey);
@@ -294,13 +294,13 @@ static gboolean AMQPSend(const char *event, const char *msg) {
   reply = amqp_channel_close(conn, 1, AMQP_REPLY_SUCCESS);
   if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
     fprintf(stderr, "amqp_channel_close\n");
-    return FALSE;
+    goto AMQP_CONN_ERROR;
   }
 
   reply = amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
   if (reply.reply_type != AMQP_RESPONSE_NORMAL) {
     fprintf(stderr, "amqp_connection_close\n");
-    return FALSE;
+    goto AMQP_CONN_ERROR;
   }
 
   x = amqp_destroy_connection(conn);
@@ -309,23 +309,31 @@ static gboolean AMQPSend(const char *event, const char *msg) {
     return FALSE;
   }
   return TRUE;
+AMQP_CONN_ERROR:
+  fprintf(stderr, "amqp_destroy_connection\n");
+  x = amqp_destroy_connection(conn);
+  if (x < 0) {
+    fprintf(stderr, "amqp_destroy_connection failure\n");
+  }
+  return FALSE;
 }
 
 gboolean push_event_via_value(DBG_Struct *dbg, ValueStruct *val) {
-  json_object *obj, *body, *event;
+  ValueStruct *body, *event;
+  json_object *obj;
 
-  obj = push_event_conv_value(val);
-  if (!json_object_object_get_ex(obj, "body", &body)) {
-    fprintf(stderr, "invalid value\n");
+  event = GetItemLongName(val,"event");
+  if (event == NULL) {
+    Warning("no [event] record");
     return FALSE;
   }
-  if (!json_object_object_get_ex(obj, "event", &event)) {
-    fprintf(stderr, "invalid value\n");
+  body = GetItemLongName(val,"body");
+  if (body == NULL) {
+    Warning("no [body] record");
     return FALSE;
   }
-
-  return push_event_via_json(dbg, (const char *)json_object_get_string(event),
-                             body);
+  obj = push_event_conv_value(body);
+  return push_event_via_json(dbg,ValueToString(event, NULL),obj);
 }
 
 gboolean push_event_via_json(DBG_Struct *dbg, const char *event,

--- a/dblib/monpushevent.c
+++ b/dblib/monpushevent.c
@@ -220,7 +220,7 @@ json_object *push_event_conv_value(ValueStruct *v) {
 }
 
 static gboolean AMQPSend(const char *event, const char *msg) {
-  char *p, *hostname, *exchange, *routingkey;
+  char *p, *hostname, *exchange, routingkey[SIZE_LONGNAME+1];
   char *user, *pass;
   int port, status, x;
   amqp_socket_t *socket = NULL;
@@ -239,7 +239,8 @@ static gboolean AMQPSend(const char *event, const char *msg) {
   if ((p = getenv("MON_AMQP_EXCHANGE")) != NULL) {
     exchange = p;
   }
-  routingkey = g_strdup_printf("tenant.%s.%s", getenv("MCP_TENANT"), event);
+  snprintf(routingkey,SIZE_LONGNAME,"tenant.%s.%s", getenv("MCP_TENANT"), event);
+  routingkey[SIZE_LONGNAME] = 0;
   user = "guest";
   if ((p = getenv("MON_AMQP_USER")) != NULL) {
     user = p;
@@ -289,7 +290,6 @@ static gboolean AMQPSend(const char *event, const char *msg) {
       goto AMQP_CONN_ERROR;
     }
   }
-  g_free(routingkey);
 
   reply = amqp_channel_close(conn, 1, AMQP_REPLY_SUCCESS);
   if (reply.reply_type != AMQP_RESPONSE_NORMAL) {

--- a/include/struct.h
+++ b/include/struct.h
@@ -82,11 +82,7 @@ typedef struct {
 
 typedef struct _RecordStruct {
   char *name;
-  char *filename;
   ValueStruct *value;
-  char *dbname;
-  char *dbgname;
-  struct _RecordStruct *dbreal;
   int type;
   union {
     DB_Struct *db;
@@ -94,6 +90,11 @@ typedef struct _RecordStruct {
 } RecordStruct;
 
 #define RecordDB(rec) ((rec)->opt.db)
+
+typedef struct _RecordStructMeta {
+  char *name;
+  char *gname;
+} RecordStructMeta;
 
 typedef struct {
   char func[SIZE_FUNC];
@@ -289,10 +290,12 @@ typedef struct {
   size_t cDB;
   GHashTable *DB_Table;
   RecordStruct **db;
+  RecordStructMeta **dbmeta;
   size_t nports;
   Port **ports;
   RecordStruct *sparec;
   RecordStruct **windows;
+  RecordStructMeta **windowsmeta;
   size_t cWindow;
   GHashTable *whash;
   WindowBind **binds;

--- a/include/struct.h
+++ b/include/struct.h
@@ -77,13 +77,16 @@ typedef struct {
   char *gname;
 } DB_Struct;
 
-#define RECORD_NULL 0
-#define RECORD_DB   1
+#define RECORD_NULL    0
+#define RECORD_DB      1
 
 typedef struct _RecordStruct {
   char *name;
   char *filename;
   ValueStruct *value;
+  char *dbname;
+  char *dbgname;
+  struct _RecordStruct *dbreal;
   int type;
   union {
     DB_Struct *db;

--- a/include/struct.h
+++ b/include/struct.h
@@ -78,10 +78,11 @@ typedef struct {
 } DB_Struct;
 
 #define RECORD_NULL 0
-#define RECORD_DB 1
+#define RECORD_DB   1
 
 typedef struct _RecordStruct {
   char *name;
+  char *filename;
   ValueStruct *value;
   int type;
   union {

--- a/libs/DBparser.c
+++ b/libs/DBparser.c
@@ -437,7 +437,7 @@ static RecordStruct *DB_Parse(CURFILE *in, char *name, char *gname,
   PathStruct *path;
 
   dbgprintf("fScript = %d", fScript);
-  ret = DD_Parse(in);
+  ret = DD_Parse(in,name);
   if (ret == NULL) {
     Error("DB_Parse Error (%s).", name);
   }
@@ -447,6 +447,9 @@ static RecordStruct *DB_Parse(CURFILE *in, char *name, char *gname,
   } else {
     ret->type = RECORD_NULL;
   }
+  if (GetDBRecMemSave()) {
+    FreeRecordValue(ret);
+  }
   SetReserved(in, DB_Reserved);
   while (GetSymbol != T_EOF) {
     switch (ComToken) {
@@ -454,7 +457,7 @@ static RecordStruct *DB_Parse(CURFILE *in, char *name, char *gname,
       switch (GetName) {
       case T_SYMBOL:
         sprintf(buff, "%s.db", ComSymbol);
-        use = ReadRecordDefine(buff);
+        use = ReadRecordDefine(buff,TRUE);
         if (use == NULL) {
           ParError("define not found");
         } else {

--- a/libs/DBparser.c
+++ b/libs/DBparser.c
@@ -510,11 +510,8 @@ static RecordStruct *DB_Parse(CURFILE *in, char *name, char *gname,
   if (strcasestr(name,".db")) {
     ret->type = RECORD_DB;
     RecordDB(ret) = InitDB_Struct(gname);
-    ret->dbreal = NULL;
-fprintf(stderr,"DB_Parse RECORD_DB\n");
   } else {
     ret->type = RECORD_NULL;
-fprintf(stderr,"DB_Parse RECORD_NULL\n");
   }
   SetReserved(in, DB_Reserved);
   while (GetSymbol != T_EOF) {
@@ -670,12 +667,9 @@ extern RecordStruct *DB_Parser(char *name, char *gname, Bool fScript) {
   CURFILE *in, root;
 
   root.next = NULL;
-  fprintf(stderr,"DB_Parser name  = [%s] gname = [%s]\n", name,gname);
   if (stat(name, &stbuf) == 0) {
     if ((in = PushLexInfo(&root, name, RecordDir, DB_Reserved)) != NULL) {
       ret = DB_Parse(in, name, gname, fScript);
-      ret->dbname = StrDup(name);
-      ret->dbgname = StrDup(gname);
       DropLexInfo(&in);
       ResolveAlias(ret, ret->value);
     } else {
@@ -685,28 +679,4 @@ extern RecordStruct *DB_Parser(char *name, char *gname, Bool fScript) {
     ret = NULL;
   }
   return (ret);
-}
-
-extern RecordStruct *DB_Parser_Lazy_Real(RecordStruct *rec) {
-  if (rec == NULL) {
-    Error("DB_Parser_Lazy_Real rec = NULL");
-  }
-  if (rec->dbreal == NULL) {
-    rec->dbreal = DB_Parser(rec->dbname,rec->dbgname,TRUE);
-fprintf(stderr,"DB_Parser_Lazy_Real real:%p\n",rec->dbreal);
-  }
-  return rec->dbreal;
-}
-
-extern void DB_Parser_Lazy_Free(RecordStruct *rec) {
-  if (rec != NULL && rec->type == RECORD_DB && rec->dbname != NULL) {
-    if (rec->value != NULL) {
-      FreeValueStruct(rec->value);
-      rec->value = NULL;
-    }
-    if (rec->dbreal != NULL) {
-      FreeRecordStruct(rec->dbreal);
-      rec->dbreal = NULL;
-    }
-  }
 }

--- a/libs/DBparser.c
+++ b/libs/DBparser.c
@@ -158,6 +158,71 @@ static DB_Struct *InitDB_Struct(char *gname) {
   return (ret);
 }
 
+static void FreeDB_Operation(DB_Operation *op) {
+  if (op->proc != NULL) {
+    FreeLBS(op->proc);
+  }
+  if (op->name != NULL) {
+    xfree(op->name);
+  }
+  if (op->args != NULL) {
+    FreeValueStruct(op->args);
+  }
+  xfree(op);
+}
+
+static void FreePathStruct(PathStruct *path) {
+  int i;
+  if (path == NULL) {
+    return;
+  }
+  if (path->name != NULL) {
+    xfree(path->name);
+  }
+  if (path->ops != NULL) {
+    for(i=0;i<path->ocount;i++) {
+      FreeDB_Operation(path->ops[i]);
+    }
+    xfree(path->ops);
+  }
+  DestroyHashTable(path->opHash);
+  if (path->args != NULL) {
+    FreeValueStruct(path->args);
+  }
+  xfree(path);
+}
+
+extern void FreeDB_Struct(DB_Struct *db) {
+  int i,j;
+  char **name;
+  if (db->gname != NULL) {
+    xfree(db->gname);
+  }
+  if (db->path != NULL) {
+    for(i=0;i<db->pcount;i++) {
+      FreePathStruct(db->path[i]);
+    }
+    xfree(db->path);
+  }
+  DestroyHashTable(db->paths);
+  if (db->pkey != NULL) {
+    if (db->pkey->item != NULL) {
+      for(i=0;db->pkey->item[i]!=NULL;i++) {
+        name = db->pkey->item[i];
+        for(j=0;name[j]!=NULL;j++) {
+          xfree(name[j]);
+        }
+        xfree(name);
+      }
+      xfree(db->pkey->item);
+    }
+    xfree(db->pkey);
+  }
+  DestroyHashTable(db->opHash);
+  DestroyHashTable(db->use);
+  xfree(db);
+}
+
 static DB_Operation *NewOperation(char *name) {
   DB_Operation *op;
 
@@ -193,6 +258,7 @@ static PathStruct *NewPathStruct(int usage) {
   ret->args = NULL;
   return (ret);
 }
+
 
 static void EnterUse(RecordStruct *root, char *name, RecordStruct *rec) {
   if (g_hash_table_lookup(RecordDB(root)->use, name) == NULL) {
@@ -441,14 +507,14 @@ static RecordStruct *DB_Parse(CURFILE *in, char *name, char *gname,
   if (ret == NULL) {
     Error("DB_Parse Error (%s).", name);
   }
-  if (!stricmp(strrchr(name, '.'), ".db")) {
+  if (strcasestr(name,".db")) {
     ret->type = RECORD_DB;
     RecordDB(ret) = InitDB_Struct(gname);
+    ret->dbreal = NULL;
+fprintf(stderr,"DB_Parse RECORD_DB\n");
   } else {
     ret->type = RECORD_NULL;
-  }
-  if (GetDBRecMemSave()) {
-    FreeRecordValue(ret);
+fprintf(stderr,"DB_Parse RECORD_NULL\n");
   }
   SetReserved(in, DB_Reserved);
   while (GetSymbol != T_EOF) {
@@ -604,11 +670,12 @@ extern RecordStruct *DB_Parser(char *name, char *gname, Bool fScript) {
   CURFILE *in, root;
 
   root.next = NULL;
-  dbgprintf("name  = [%s]", name);
-  dbgprintf("gname = [%s]", gname);
+  fprintf(stderr,"DB_Parser name  = [%s] gname = [%s]\n", name,gname);
   if (stat(name, &stbuf) == 0) {
     if ((in = PushLexInfo(&root, name, RecordDir, DB_Reserved)) != NULL) {
       ret = DB_Parse(in, name, gname, fScript);
+      ret->dbname = StrDup(name);
+      ret->dbgname = StrDup(gname);
       DropLexInfo(&in);
       ResolveAlias(ret, ret->value);
     } else {
@@ -618,4 +685,28 @@ extern RecordStruct *DB_Parser(char *name, char *gname, Bool fScript) {
     ret = NULL;
   }
   return (ret);
+}
+
+extern RecordStruct *DB_Parser_Lazy_Real(RecordStruct *rec) {
+  if (rec == NULL) {
+    Error("DB_Parser_Lazy_Real rec = NULL");
+  }
+  if (rec->dbreal == NULL) {
+    rec->dbreal = DB_Parser(rec->dbname,rec->dbgname,TRUE);
+fprintf(stderr,"DB_Parser_Lazy_Real real:%p\n",rec->dbreal);
+  }
+  return rec->dbreal;
+}
+
+extern void DB_Parser_Lazy_Free(RecordStruct *rec) {
+  if (rec != NULL && rec->type == RECORD_DB && rec->dbname != NULL) {
+    if (rec->value != NULL) {
+      FreeValueStruct(rec->value);
+      rec->value = NULL;
+    }
+    if (rec->dbreal != NULL) {
+      FreeRecordStruct(rec->dbreal);
+      rec->dbreal = NULL;
+    }
+  }
 }

--- a/libs/DBparser.c
+++ b/libs/DBparser.c
@@ -259,7 +259,6 @@ static PathStruct *NewPathStruct(int usage) {
   return (ret);
 }
 
-
 static void EnterUse(RecordStruct *root, char *name, RecordStruct *rec) {
   if (g_hash_table_lookup(RecordDB(root)->use, name) == NULL) {
     g_hash_table_insert(RecordDB(root)->use, name, rec);

--- a/libs/DBparser.h
+++ b/libs/DBparser.h
@@ -26,8 +26,6 @@
 
 extern void DB_ParserInit(void);
 extern RecordStruct *DB_Parser(char *name, char *gname, Bool fScript);
-extern RecordStruct *DB_Parser_Lazy_Real(RecordStruct *rec);
-extern void DB_Parser_Lazy_Free(RecordStruct *rec);
 extern void FreeDB_Struct(DB_Struct *);
 
 #undef GLOBAL

--- a/libs/DBparser.h
+++ b/libs/DBparser.h
@@ -26,6 +26,9 @@
 
 extern void DB_ParserInit(void);
 extern RecordStruct *DB_Parser(char *name, char *gname, Bool fScript);
+extern RecordStruct *DB_Parser_Lazy_Real(RecordStruct *rec);
+extern void DB_Parser_Lazy_Free(RecordStruct *rec);
+extern void FreeDB_Struct(DB_Struct *);
 
 #undef GLOBAL
 #ifdef _DB_PARSER

--- a/libs/DDparser.c
+++ b/libs/DDparser.c
@@ -113,6 +113,10 @@ extern RecordStruct *ReadRecordDefine(const char *name,Bool use_cache) {
 }
 
 extern void FreeRecordStruct(RecordStruct *rec) {
+#ifdef MON_MEM_SAVE_TRACE
+  fprintf(stderr,"FreeRecordStruct %p name:%s ",rec,rec->name);
+  ResetTotalFreeSize();
+#endif
   if (rec == NULL) {
     return;
   }
@@ -126,6 +130,9 @@ extern void FreeRecordStruct(RecordStruct *rec) {
     FreeDB_Struct(RecordDB(rec));
   }
   xfree(rec);
+#ifdef MON_MEM_SAVE_TRACE
+  fprintf(stderr,"size:%lu\n",GetTotalFreeSize());
+#endif
 }
 
 extern RecordStructMeta *NewRecordStructMeta(const char *name, const char *gname) {

--- a/libs/DDparser.h
+++ b/libs/DDparser.h
@@ -22,8 +22,10 @@
 #include "struct.h"
 #include "Lex.h"
 
-extern RecordStruct *DD_Parse(CURFILE *in);
-extern RecordStruct *ParseRecordFile(char *name);
-extern RecordStruct *ParseRecordMem(char *mem);
-extern RecordStruct *ReadRecordDefine(char *name);
+extern RecordStruct *DD_Parse(CURFILE *in,const char *filename);
+extern RecordStruct *ParseRecordFile(const char *name);
+extern RecordStruct *ParseRecordMem(const char *mem);
+extern RecordStruct *ReadRecordDefine(const char *name,Bool use_cache);
+extern void MallocRecordValue(RecordStruct *);
+extern void FreeRecordValue(RecordStruct *);
 #endif

--- a/libs/DDparser.h
+++ b/libs/DDparser.h
@@ -26,6 +26,7 @@ extern RecordStruct *DD_Parse(CURFILE *in,const char *filename);
 extern RecordStruct *ParseRecordFile(const char *name);
 extern RecordStruct *ParseRecordMem(const char *mem);
 extern RecordStruct *ReadRecordDefine(const char *name,Bool use_cache);
+extern void FreeRecordStruct(RecordStruct *);
 extern void MallocRecordValue(RecordStruct *);
 extern void FreeRecordValue(RecordStruct *);
 #endif

--- a/libs/DDparser.h
+++ b/libs/DDparser.h
@@ -27,6 +27,5 @@ extern RecordStruct *ParseRecordFile(const char *name);
 extern RecordStruct *ParseRecordMem(const char *mem);
 extern RecordStruct *ReadRecordDefine(const char *name,Bool use_cache);
 extern void FreeRecordStruct(RecordStruct *);
-extern void MallocRecordValue(RecordStruct *);
-extern void FreeRecordValue(RecordStruct *);
+extern RecordStructMeta *NewRecordStructMeta(const char *name, const char *gname);
 #endif

--- a/libs/DIparser.c
+++ b/libs/DIparser.c
@@ -1023,7 +1023,7 @@ static DI_Struct *ParDI(CURFILE *in, char *ld, char *bd, char *db,
       if (GetSymbol == T_SYMBOL) {
         if (parse_type >= P_LD) {
           sprintf(buff, "%s.rec", ComSymbol);
-          ThisEnv->linkrec = ReadRecordDefine(buff);
+          ThisEnv->linkrec = ReadRecordDefine(buff,TRUE);
         } else {
           break;
         }

--- a/libs/LDparser.c
+++ b/libs/LDparser.c
@@ -74,7 +74,6 @@ static TokenTable tokentable[] = {{"data", T_DATA},
                                   {"", 0}};
 
 static GHashTable *Reserved;
-static GHashTable *DBParsed;
 
 static GHashTable *Records;
 
@@ -168,16 +167,11 @@ static void _ParDB(CURFILE *in, LD_Struct *ld, char *dbgname,
       *q = 0;
     }
     sprintf(name, "%s/%s.db", p, table_name);
-    if ((db = g_hash_table_lookup(DBParsed, name)) == NULL) {
-      dbgprintf("Parsed %s\n", table_name);
-      if (g_hash_table_lookup(ld->DB_Table, table_name) == NULL) {
-        db = DB_Parser(name, dbgname, TRUE);
-      } else {
-        ParError("same db appier");
-      }
-      g_hash_table_insert(DBParsed, StrDup(name), (void *)db);
+    dbgprintf("Parsed %s\n", table_name);
+    if (g_hash_table_lookup(ld->DB_Table, table_name) == NULL) {
+      db = DB_Parser(name, dbgname, TRUE);
     } else {
-      dbgprintf("Already Parsed %s\n", name);
+      ParError("same db appier");
     }
     if (db != NULL) {
       rtmp = (RecordStruct **)xmalloc(sizeof(RecordStruct *) * (ld->cDB + 1));
@@ -458,6 +452,5 @@ extern void LD_ParserInit(void) {
   Reserved = MakeReservedTable(tokentable);
 
   Records = NewNameHash();
-  DBParsed = NewNameHash();
   MessageHandlerInit();
 }

--- a/libs/LDparser.c
+++ b/libs/LDparser.c
@@ -85,8 +85,8 @@ extern RecordStruct *GetWindow(char *name) {
   if (name != NULL) {
     rec = (RecordStruct *)g_hash_table_lookup(Records, name);
     if (rec == NULL) {
-      fname[SIZE_LONGNAME] = 0;
       snprintf(fname,SIZE_LONGNAME,"%s.rec", name);
+      fname[SIZE_LONGNAME] = 0;
       rec = ReadRecordDefine(fname,!GetScrRecMemSave());
       if (rec != NULL) {
         g_hash_table_insert(Records, g_strdup(name), rec);
@@ -133,8 +133,8 @@ static void ParWindow(CURFILE *in, LD_Struct *ld) {
         ld->windows = wn;
         ld->windows[ld->cWindow] = window;
         ld->windowsmeta = wnm;
-        rname[SIZE_LONGNAME] = 0;
         snprintf(rname,SIZE_LONGNAME,"%s.rec",wname);
+        rname[SIZE_LONGNAME] = 0;
         ld->windowsmeta[ld->cWindow] = NewRecordStructMeta(rname,NULL);
         ld->cWindow++;
         if (window != NULL) {

--- a/libs/directory.c
+++ b/libs/directory.c
@@ -48,6 +48,9 @@
 static GHashTable *DBMS_Table;
 static char *MONDB_LoadPath;
 
+static Bool ScrRecMemSave;
+static Bool DBRecMemSave;
+
 typedef struct {
   char *name;
   char *type;
@@ -97,6 +100,8 @@ extern void InitDirectory(void) {
   BD_ParserInit();
   DBD_ParserInit();
   DI_ParserInit();
+  ScrRecMemSave = FALSE;
+  DBRecMemSave = FALSE;
 }
 
 extern DBG_Struct *GetDBG(char *name) {
@@ -266,4 +271,20 @@ extern RecordStruct *GetTableDBG(char *gname, char *tname) {
     db = NULL;
   }
   return (db);
+}
+
+extern void SetScrRecMemSave(Bool enabled) {
+  ScrRecMemSave = enabled;
+}
+
+extern void SetDBRecMemSave(Bool enabled) {
+  DBRecMemSave = enabled;
+}
+
+extern Bool GetScrRecMemSave(void) {
+  return ScrRecMemSave;
+}
+
+extern Bool GetDBRecMemSave(void) {
+  return DBRecMemSave;
 }

--- a/libs/directory.h
+++ b/libs/directory.h
@@ -52,6 +52,11 @@ extern DB_Func *EnterDB_Function(char *name, DB_OPS *ops, int type,
                                  char *commentEnd);
 extern RecordStruct *GetTableDBG(char *gname, char *tname);
 
+extern void SetScrRecMemSave(Bool enabled);
+extern void SetDBRecMemSave(Bool enabled);
+extern Bool GetScrRecMemSave();
+extern Bool GetDBRecMemSave();
+
 #define P_NONE 0
 #define P_LD 1
 #define P_ALL 2

--- a/libs/message.c
+++ b/libs/message.c
@@ -31,6 +31,7 @@
 #include <time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/resource.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
@@ -323,4 +324,11 @@ extern void Time(char *str) {
   now = GetNowTime();
   fprintf(stderr, "%6ld(ms) %s\n", now - last, str);
   last = now;
+}
+
+extern void PrintRSS(const char *head) {
+  struct rusage r;
+  if (getrusage(RUSAGE_SELF, &r) == 0) {
+      fprintf(stderr,"%s maxrss:%ld\n",head,r.ru_maxrss);
+  }
 }

--- a/libs/message.h
+++ b/libs/message.h
@@ -48,6 +48,7 @@ extern void SetMessageFunction(void (*func)(int level, char *file, int line,
 extern unsigned long GetNowTime(void);
 extern void TimerPrintf(long start, long end, char *format, ...);
 extern void Time(char *);
+extern void PrintRSS(const char*);
 
 #ifndef Bool
 #define Bool int

--- a/tools/pandadb.c
+++ b/tools/pandadb.c
@@ -386,7 +386,7 @@ static void InitSystem(char *name) {
     exit(1);
   }
 
-  ThisDB = ThisDBD->db;
+  DBGroup_Init(ThisDBD->db,NULL);
   DB_Table = ThisDBD->DBD_Table;
 
   if (ThisDBD->cDB > 0) {


### PR DESCRIPTION
## 概要

* 画面定義体の逐次確保
    * apsトランザクション実行前にLDの画面定義体全部をチェックし、NULLならパースして確保する
    * apsトランザクション実行後、LDの画面定義体をすべて解放する
    * apsに環境変数MON_SCR_MEM_SAVE=1を設定することで有効になる

* DB定義体の逐次確保
    * MONFUNC実行時に操作するテーブルのDB定義体のみをパースして確保する
        * dblib/dbgroup.cのSetCtrlRecord()
    * apsトランザクション実行後、LDのDB定義体をすべて解放する
    * apsに環境変数MON_SCR_DB_SAVE=1を設定することで有効になる

## 実装詳細

* 画面定義体、DB定義体ともにパース時に読み込み元のファイル名などをRecordStructMeta構造体に保存しておき、後でパースできるようにしている
* DB_ParserではパースしたValueStruct(SQLの引数や返り値として使用)の参照をSQL組み立て時のポインタとして保存しているため、逐次パース時に(RecParserだけでなく)DB_Parserを行う必要があった。
(ValueStructの置き換えのみではすまなかった。)

## 備考

* 初回のSetupDirectoryでの各定義体パースはスキップできなかった
    * パース結果後のValueStructのサイズを取得したりして使用していたため

## 確認

テスト用簡易アプリケーションでvalgrindを使いリークやエラーがないことを確認した

    * https://github.com/yusukemihara/PANDA-SAMPLE/tree/master/cobol%2Bterm/dbtest51
    * https://github.com/yusukemihara/PANDA-SAMPLE/tree/master/cobol%2Bterm/pushevent

また日レセの診療行為のaps(orca21)でvalgringを使い動的チェックしリークやエラーがないことを確認した。
    * monpushevent周りのリークが見つかったので修正した