### PR TITLE
非SSOオンプレ環境にログインできない問題の修正

### DIFF
--- a/glclient/openid_connect.c
+++ b/glclient/openid_connect.c
@@ -69,7 +69,7 @@ json_object *parse_header_text(char *header_text) {
 
 json_object *request(CURL *curl, char *uri, int method, json_object *params, char *cookie) {
   LargeByteString *body, *headers;
-  json_object *res, *res_headers;
+  json_object *res = NULL, *res_headers;
   struct curl_slist *request_headers = NULL;
   int response_code;
 
@@ -95,7 +95,9 @@ json_object *request(CURL *curl, char *uri, int method, json_object *params, cha
 
   curl_easy_perform(curl);
 
-  res = json_tokener_parse(LBS_Body(body));
+  if(LBS_Body(body) != NULL) {
+    res = json_tokener_parse(LBS_Body(body));
+  }
   if (res == NULL) {
     res = json_object_new_object();
   }


### PR DESCRIPTION
@yusukemihara 修正しましたので確認をよろしくお願いします。

`curl_easy_setopt(ctx->Curl, CURLOPT_USERPWD, userpass)` を実行する条件が逆だったのが原因で、非SSOのときに実行しなければなりませんでした。