### PR TITLE
libwebsockets >= 2.0.3 のときだけLWS_SERVER_OPTION_DO_SSL_GLOBAL_INITを設定する

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,11 @@ if test "x$enable_client" = "xyes"; then
 	[
 		libwebsockets	>= 1.7.1
 	])
+
+	PKG_CHECK_MODULES(CHECK_LWS, libwebsockets >= 2.0.3,
+	[
+		AC_DEFINE(LWS_2,1,"")
+	], [])
 fi
 
 if test "x$enable_client" = "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,10 @@ if test "x$enable_client" = "xyes"; then
 	PKG_CHECK_MODULES(CHECK_LWS, libwebsockets >= 2.0.3,
 	[
 		AC_DEFINE(LWS_2,1,"")
-	], [])
+	], [
+		PKG_CHECK_MODULES(CHECK_GTK_VER,libwebsockets >= 1.7.1,
+		[])
+    ])
 fi
 
 if test "x$enable_client" = "xyes"

--- a/glclient/push_client.c
+++ b/glclient/push_client.c
@@ -334,6 +334,9 @@ static void Execute() {
   path[sizeof(path) - 1] = '\0';
   i.path = path;
 
+#ifdef LWS_2
+  info.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+#endif
   info.port = CONTEXT_PORT_NO_LISTEN;
   info.protocols = protocols;
   info.gid = -1;


### PR DESCRIPTION
#193 の対応

configure.acでlibwebsocketsのバージョンを調べて#ifdefする。

