### PR TITLE
monblob,monpushevent関連のsequenceやindexが中途半端に残っているとmonsetupでエラーになるのを修正

### DIFF
--- a/dblib/bytea.c
+++ b/dblib/bytea.c
@@ -107,8 +107,14 @@ static Bool create_monblob(DBG_Struct *dbg) {
   sql = (char *)xmalloc(SIZE_BUFF);
   sprintf(sql, "DROP SEQUENCE IF EXISTS %s;", SEQMONBLOB);
   rc = ExecDBOP(dbg, sql, FALSE);
+  if (rc != MCP_OK) {
+    return FALSE;
+  }
   sprintf(sql, "DROP INDEX IF EXISTS %s_pkey;", MONBLOB);
   rc = ExecDBOP(dbg, sql, FALSE);
+  if (rc != MCP_OK) {
+    return FALSE;
+  }
   p = sql;
   p += sprintf(p, "CREATE TABLE %s (", MONBLOB);
   for (i = 0; columns[i][0] != NULL; i++) {

--- a/dblib/bytea.c
+++ b/dblib/bytea.c
@@ -105,6 +105,10 @@ static Bool create_monblob(DBG_Struct *dbg) {
   int i;
 
   sql = (char *)xmalloc(SIZE_BUFF);
+  sprintf(sql, "DROP SEQUENCE IF EXISTS %s;", SEQMONBLOB);
+  rc = ExecDBOP(dbg, sql, FALSE);
+  sprintf(sql, "DROP INDEX IF EXISTS %s_pkey;", MONBLOB);
+  rc = ExecDBOP(dbg, sql, FALSE);
   p = sql;
   p += sprintf(p, "CREATE TABLE %s (", MONBLOB);
   for (i = 0; columns[i][0] != NULL; i++) {

--- a/dblib/monpushevent.c
+++ b/dblib/monpushevent.c
@@ -68,6 +68,14 @@ static Bool create_monpushevent(DBG_Struct *dbg) {
   Bool rc;
   char *sql;
 
+  sql = "DROP SEQUENCE IF EXISTS " SEQMONPUSHEVENT ";";
+  rc = ExecDBOP(dbg, sql, FALSE);
+  sql = "DROP INDEX IF EXISTS " MONPUSHEVENT "_pkey;";
+  rc = ExecDBOP(dbg, sql, FALSE);
+  if (rc != MCP_OK) {
+    Warning("SQL Error:%s", sql);
+    return FALSE;
+  }
   sql = ""
         "CREATE TABLE " MONPUSHEVENT " ("
         "  uuid      varchar(37) PRIMARY KEY,"

--- a/dblib/monpushevent.c
+++ b/dblib/monpushevent.c
@@ -70,6 +70,10 @@ static Bool create_monpushevent(DBG_Struct *dbg) {
 
   sql = "DROP SEQUENCE IF EXISTS " SEQMONPUSHEVENT ";";
   rc = ExecDBOP(dbg, sql, FALSE);
+  if (rc != MCP_OK) {
+    Warning("SQL Error:%s", sql);
+    return FALSE;
+  }
   sql = "DROP INDEX IF EXISTS " MONPUSHEVENT "_pkey;";
   rc = ExecDBOP(dbg, sql, FALSE);
   if (rc != MCP_OK) {


### PR DESCRIPTION
日レセミドルウェアで作成するテーブルがいくつか(monpushevent,monblob,monbatchなど)あり、それらはaps実行時に動的に作られる他(関連処理実行前にテーブルチェックしてなければ作成)、monsetupコマンドでも作成されます。またテーブル作成と同時にINDEXやSEQUENCEも作成しています。

ユーザがmonpusheventなどテーブルを手動で削除した場合にmonsetupコマンドを実行すると、関連SEQUENCEやINDEXが残っているとalready existsでエラーになります。
already existsとならないよう残る可能性があるINDEXとSEQUENCEについてはテーブル作成前にDROPするよう修正しました。