### PR TITLE
プログラム更新時にクライアント強制停止ダイアログ表示前にクライアントが通信エラーになるのを防ぐ

### DIFF
--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -662,13 +662,15 @@ static void StopServers(void) {
 static void StopSystem(void) {
   fLoop = FALSE;
   fRestart = FALSE;
-  StopServers();
+  StopServers(); 
+  sleep(5);
   Message("stop system");
 }
 
 static void RestartSystem(void) {
   fRestart = FALSE;
-  StopServers();
+  sleep(10);
+  StopServers(); 
   Message("restart system");
   WfcRestartCount = 0;
 }

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -663,7 +663,6 @@ static void StopSystem(void) {
   fLoop = FALSE;
   fRestart = FALSE;
   StopServers(); 
-  sleep(5);
   Message("stop system");
 }
 

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -656,6 +656,7 @@ static void StopServers(void) {
   KillProcess(PTYPE_GLS, SIGHUP);
   KillProcess(PTYPE_APS, SIGHUP);
   KillProcess((PTYPE_WFC | PTYPE_RED | PTYPE_LOG | PTYPE_MST), SIGHUP);
+  /*再起動したglserverやapsがkill中のwfcに接続するのを防ぐ*/
   sleep(5);
 }
 
@@ -668,8 +669,9 @@ static void StopSystem(void) {
 
 static void RestartSystem(void) {
   fRestart = FALSE;
+  /*シグナルを受けて10秒待って再起動する(クライアント強制停止処理のため)*/
   sleep(10);
-  StopServers(); 
+  StopServers();
   Message("restart system");
   WfcRestartCount = 0;
 }

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -662,7 +662,7 @@ static void StopServers(void) {
 static void StopSystem(void) {
   fLoop = FALSE;
   fRestart = FALSE;
-  StopServers(); 
+  StopServers();
   Message("stop system");
 }
 


### PR DESCRIPTION
* 日レセのプログラム更新ではアプリ側でwfc,aps,glserverのプロセスの再起動を行う
* wfc,aps,glserverの再起動はmonitorへSIGHUPを送ることでやっている
    1. monitorのシグナルハンドラ内でwfc,aps,glserverのプロセスへシグナル送信
    2. wfc,aps,glserver停止 
    3. monitorでwfc,aps,glserverのSIGCHLDを補足して新しいプロセス起動
* 日レセ側でプロセス再起動前にクライアントへ強制停止命令を送る
    * クライアントは7秒に1回glserverへアクセスして停止命令が出てないか確認している
* クライアントの強制停止命令確認前にサーバが再起動するとクライアント側でglserverへの通信エラーとなる
    * 日レセ側で強制停止命令を先に出してはいるがタイミングによってはサーバ再起動の方が先になっている模様
* monitorのシグナルハンドラ内でsleep(10)してからプロセス停止処理するようにした