### PR TITLE
fix-224 APIとGLGetBLOBでblobidが不正だった場合に初期化されていないメモリ領域を返すのを修正

### DIFF
--- a/glserver/glblob.c
+++ b/glserver/glblob.c
@@ -58,8 +58,12 @@ void GLExportBLOB(char* id, char **out, size_t *size) {
   monblob_setup(dbg, FALSE);
   TransactionStart(dbg);
 
-  monblob_export_mem(dbg, id, out, size);
-  monblob_delete(dbg, id);
+  if (monblob_export_mem(dbg, id, out, size)) {
+    monblob_delete(dbg, id);
+  } else {
+    *out = NULL;
+    *size = 0;
+  }
 
   TransactionEnd(dbg);
   CloseDB(dbg);

--- a/glserver/http.c
+++ b/glserver/http.c
@@ -687,8 +687,12 @@ void APISendResponse(HTTP_REQUEST *req, json_object *obj) {
 
   if (status == 200 && id != NULL) {
     GLExportBLOB(id, &blob, &blob_size);
-    SendResponse(req, status, blob, blob_size, "Content-Type", ctype, NULL);
-    xfree(blob);
+    if (blob == NULL || blob_size <= 0) {
+      SendResponse(req, HTTP_INTERNAL_SERVER_ERROR, NULL, 0, NULL);
+    } else {
+      SendResponse(req, status, blob, blob_size, "Content-Type", ctype, NULL);
+      xfree(blob);
+    }
   } else {
     SendResponse(req, status, NULL, 0, NULL);
   }
@@ -745,7 +749,7 @@ static gboolean BLOBExportHandler(HTTP_REQUEST *req) {
     return TRUE;
   }
   GLExportBLOB(req->oid, &body, &size);
-  if (body == NULL || size == 0) {
+  if (body == NULL || size <= 0) {
     SendResponse(req, HTTP_NOT_FOUND, NULL, 0, NULL);
     return TRUE;
   } else {


### PR DESCRIPTION
#224 

手元のAPIの単体テストでAPIレスポンスに不正なblobidを指定して、HTTP STATUS 500を返してbody_size=0なことを確認。