### PR TITLE
monitorで使用していないシグナルをブロックする

### DIFF
--- a/glserver/glserver.c
+++ b/glserver/glserver.c
@@ -81,8 +81,6 @@ static ARG_TABLE option[] = {
 
     {NULL, 0, FALSE, NULL, NULL}};
 
-static sigset_t SigMask;
-
 static void SetDefault(void) {
   PortNumber = PORT_GLTERM;
   PortSysData = SYSDATA_PORT;
@@ -193,7 +191,7 @@ extern int main(int argc, char **argv) {
   // SIGINTをUNBLOCK
   sigemptyset(&sigmask);
   sigaddset(&sigmask, SIGINT);
-  sigprocmask(SIG_UNBLOCK, &sigmask, &SigMask);
+  sigprocmask(SIG_UNBLOCK, &sigmask, NULL);
 
   memset(&sa, 0, sizeof(struct sigaction));
   sa.sa_handler = SIG_IGN;

--- a/glserver/glserver.c
+++ b/glserver/glserver.c
@@ -81,6 +81,8 @@ static ARG_TABLE option[] = {
 
     {NULL, 0, FALSE, NULL, NULL}};
 
+static sigset_t SigMask;
+
 static void SetDefault(void) {
   PortNumber = PORT_GLTERM;
   PortSysData = SYSDATA_PORT;
@@ -183,9 +185,15 @@ static void InitSystem(void) {
 
 extern int main(int argc, char **argv) {
   struct sigaction sa;
+  sigset_t sigmask;
 
   // PGID変更
   setsid();
+
+  // SIGINTをUNBLOCK
+  sigemptyset(&sigmask);
+  sigaddset(&sigmask, SIGINT);
+  sigprocmask(SIG_UNBLOCK, &sigmask, &SigMask);
 
   memset(&sa, 0, sizeof(struct sigaction));
   sa.sa_handler = SIG_IGN;

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -802,6 +802,7 @@ extern int main(int argc, char **argv) {
   sigaddset(&sigmask, SIGUSR2);
   sigprocmask(SIG_BLOCK, &sigmask, &SigMask);
 
+  memset(&sa, 0, sizeof(sa));
   sa.sa_handler = (void *)RestartSystem;
   sa.sa_flags |= SA_RESTART;
   if (sigaction(SIGHUP, &sa, NULL) != 0) {

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -78,8 +78,6 @@ static volatile sig_atomic_t fLoop = TRUE;
 static volatile sig_atomic_t fRestart = TRUE;
 static volatile sig_atomic_t WfcRestartCount = 0;
 
-static sigset_t SigMask;
-
 #define MAX_WFC_RESTART_COUNT 5
 
 #define PTYPE_NULL (unsigned char)0x00
@@ -800,7 +798,7 @@ extern int main(int argc, char **argv) {
   sigaddset(&sigmask, SIGTERM);
   /*sigaddset(&sigmask, SIGUSR1); /etc/init.d/jma-receiptで利用 */
   sigaddset(&sigmask, SIGUSR2);
-  sigprocmask(SIG_BLOCK, &sigmask, &SigMask);
+  sigprocmask(SIG_BLOCK, &sigmask, NULL);
 
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = (void *)RestartSystem;


### PR DESCRIPTION
* 日レセプログラム更新の際にバッチスクリプトからmonitorにSIGHUPを送って、monitorがシグナルハンドラによりaps、wfc、glserverのプロセスの再起動(SIGHUP送信、SIGCHLD受信、プロセスフォーク)を行なう
* プログラム更新を2回行って、2回monitorによる再起動を行った際にmonitorが異常終了する不具合がある
    * 再現する場合としない場合がある
* valgrindでmonitorを実行したところ、sigaction構造体の初期化漏れがあったが、それ以外に動的なエラーはなかった。
* syslogからすると異常終了時にmonitorがなんらかのシグナルを受けて終了しているように見える
    * タイミング的にはwfc停止前後なのでスクリプトからSIGHUPを受けた後
* 異常終了の原因が不明だが、sigaction構造体の初期化漏れ修正と不要なシグナルのブロックを行った。