### PR TITLE
websocketのproxy対応

### DIFF
--- a/glclient/push_client.c
+++ b/glclient/push_client.c
@@ -295,6 +295,28 @@ static int callback_push_receive(struct lws *wsi,
   return 0;
 }
 
+/*
+env http_proxy=http://host:port -> host:port
+*/
+static const char* ProxyAddress() {
+  char *p,*env_proxy;
+  env_proxy = getenv("http_proxy");
+  if (env_proxy == NULL) {
+    env_proxy = getenv("https_proxy");
+  }
+  if (env_proxy == NULL) {
+    env_proxy = getenv("all_proxy");
+  }
+  if (env_proxy == NULL) {
+    return NULL;
+  }
+  if ((p = strstr(env_proxy,"://")) != NULL) {
+    p += 3;
+    return (const char*)p;
+  }
+  return NULL;
+}
+
 /* list of supported protocols and callbacks */
 static struct lws_protocols protocols[] = {
     {
@@ -341,6 +363,7 @@ static void Execute() {
   info.protocols = protocols;
   info.gid = -1;
   info.uid = -1;
+  info.http_proxy_address = ProxyAddress();
 
   if (fSSL) {
     info.ssl_ca_filepath = CAFile;


### PR DESCRIPTION
libcurl用の環境変数http_proxy、https_proxyからlibwebsocketのhttp_proxy_addressを設定する。

* 手元の環境のプロキシを立ててhttp_proxy、https_proxy環境変数が有効なことを確認