### PR TITLE
monitorによる子プロセス停止の修正

### DIFF
--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -34,7 +34,6 @@
 #include <string.h>
 #include <libgen.h>
 #include <sys/socket.h>
-#include <sys/prctl.h>
 #include <pthread.h>
 #include <glib.h>
 
@@ -410,8 +409,6 @@ extern int main(int argc, char **argv) {
   if (sigaction(SIGUSR2, &sa, NULL) != 0) {
     Error("sigaction(2) failure");
   }
-
-  prctl(PR_SET_PDEATHSIG, SIGHUP);
 
   stdout_path = getenv("APS_DEBUG_STDOUT_PATH");
   if (stdout_path != NULL) {

--- a/glclient/protocol.c
+++ b/glclient/protocol.c
@@ -79,22 +79,24 @@ static void CommError(CURLcode res) {
   msg = curl_easy_strerror(res);
   if (msg == NULL) {
     Error(_("comm error:other error"));
+  } else {
+    Warning(msg);
+    if (strncasecmp(msg,"Peer certificate cannot be authenticated with given CA certificates",ERR_MSG_MAX_LEN) == 0) {
+      Error(_("Peer certificate cannot be authenticated with given CA certificates"));
+    } else if (strncasecmp(msg,"Problem with the SSL CA cert (path? access rights?)",ERR_MSG_MAX_LEN) == 0) {
+      Error(_("Problem with the SSL CA cert (path? access rights?)"));
+    } else if (strncasecmp(msg,"SSL connect error",ERR_MSG_MAX_LEN) == 0) {
+      Error(_("SSL connect error"));
+    } else if (strncasecmp(msg,"Problem with the local SSL certificate",ERR_MSG_MAX_LEN) == 0) {
+      Error(_("Problem with the local SSL certificate"));
+    } else if (strncasecmp(msg,"Couldn't resolve host name",ERR_MSG_MAX_LEN) == 0) {
+      Error(_("Couldn't resolve host name"));
+    } else if (strncasecmp(msg,"Couldn't connect to server",ERR_MSG_MAX_LEN) == 0) {
+      Error(_("Couldn't connect to server"));
+    } else {
+      Error(_("comm error:%s"),msg);
+    }
   }
-  Warning(msg);
-  if (strncasecmp(msg,"Peer certificate cannot be authenticated with given CA certificates",ERR_MSG_MAX_LEN) == 0) {
-    Error(_("Peer certificate cannot be authenticated with given CA certificates"));
-  } else if (strncasecmp(msg,"Problem with the SSL CA cert (path? access rights?)",ERR_MSG_MAX_LEN) == 0) {
-    Error(_("Problem with the SSL CA cert (path? access rights?)"));
-  } else if (strncasecmp(msg,"SSL connect error",ERR_MSG_MAX_LEN) == 0) {
-    Error(_("SSL connect error"));
-  } else if (strncasecmp(msg,"Problem with the local SSL certificate",ERR_MSG_MAX_LEN) == 0) {
-    Error(_("Problem with the local SSL certificate"));
-  } else if (strncasecmp(msg,"Couldn't resolve host name",ERR_MSG_MAX_LEN) == 0) {
-    Error(_("Couldn't resolve host name"));
-  } else if (strncasecmp(msg,"Couldn't connect to server",ERR_MSG_MAX_LEN) == 0) {
-    Error(_("Couldn't connect to server"));
-  }
-  Error(_("comm error:%s"),msg);
 }
 
 static LargeByteString *readbuf;

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -807,6 +807,12 @@ extern int main(int argc, char **argv) {
     Error("sigaction(2) failure");
   }
 
+  sa.sa_handler = (void *)StopSystem;
+  sa.sa_flags |= SA_RESTART;
+  if (sigaction(SIGUSR1, &sa, NULL) != 0) {
+    Error("sigaction(2) failure");
+  }
+
   StartSetup();
 
   while (fLoop) {

--- a/wfc/wfc.c
+++ b/wfc/wfc.c
@@ -41,7 +41,6 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <sys/stat.h> /*	for	mknod	*/
-#include <sys/prctl.h>
 #include <unistd.h>
 #include <glib.h>
 #include <pthread.h>
@@ -336,8 +335,6 @@ extern int main(int argc, char **argv) {
   if (stderr_path != NULL) {
     freopen(stderr_path, "w", stderr);
   }
-
-  prctl(PR_SET_PDEATHSIG, SIGHUP);
 
   InitMessage("wfc", NULL);
 


### PR DESCRIPTION
## バグ詳細

1. monitorへのSIGUSR1による停止でSIGUSR1のシグナルハンドラ(StopSystem)が設定されておらず単純にmonitor自身がSIGUSR1で停止していた。
2. aps,glserver,wfcは prctrlにより親プロセス(monitor)停止に連動して停止していたが、dbredirectorはprctrlを実行しておらず systemctrl stop jma-receipt でもdbredirectorのプロセスが残っていた
3. dbredirectorが残った状態でsystemctrl start jma-receiptとすると前のdbredirectorのプロセスがportをBINDしたままなのでエラーとなる -> monitorがエラー検知して再起動を繰り返しsyslogにエラーメッセージを出し続ける
    * 手動でdbredirectorをkillするかマシンの再起動をしないといけなくなる

## 対応

* monitorにSIGUSR1のhandler(StopSystem)を設定
* aps,wfcの不要なprctrlを削除
* monitorに-debugオプションを追加
* scan-buildで出た(無関係な)glclient/protocol.cを修正

## 動作確認

* Ubuntu 18.04 16.04でsystemctrl start jma-receipt , systemctl stop jma-receipt でdbredirectorおよびその他のプロセスが正しく起動、終了することを確認
* プログラム更新による再起動(monitorへのSIGHUPシグナル)が正しく動作することを確認
* monitorの-debugオプションでsyslogにプロセス起動、停止のログが出ることを確認