### PR TITLE
monitorをSIGUSR1で直ちに停止させる方針へ変更

### DIFF
--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <libgen.h>
 #include <sys/socket.h>
+#include <sys/prctl.h>
 #include <pthread.h>
 #include <glib.h>
 
@@ -409,6 +410,9 @@ extern int main(int argc, char **argv) {
   if (sigaction(SIGUSR2, &sa, NULL) != 0) {
     Error("sigaction(2) failure");
   }
+
+  /* 親プロセス(monitor)停止で自動停止 */
+  prctl(PR_SET_PDEATHSIG, SIGHUP);
 
   stdout_path = getenv("APS_DEBUG_STDOUT_PATH");
   if (stdout_path != NULL) {

--- a/dbstuff/dbredirector.c
+++ b/dbstuff/dbredirector.c
@@ -38,6 +38,7 @@
 #include <sys/time.h>
 #include <sys/socket.h>
 #include <sys/select.h>
+#include <sys/prctl.h>
 #include <time.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -924,6 +925,9 @@ extern void InitSystem(char *name, char *program) {
   sa.sa_flags |= SA_RESTART;
   sigemptyset(&sa.sa_mask);
   sigaction(SIGUSR1, &sa, NULL);
+
+  /* 親プロセス(monitor)停止で自動停止 */
+  prctl(PR_SET_PDEATHSIG, SIGHUP);
 
   InitDirectory();
   SetUpDirectory(Directory, NULL, NULL, NULL, P_NONE);

--- a/wfc/wfc.c
+++ b/wfc/wfc.c
@@ -41,6 +41,7 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <sys/stat.h> /*	for	mknod	*/
+#include <sys/prctl.h>
 #include <unistd.h>
 #include <glib.h>
 #include <pthread.h>
@@ -325,6 +326,9 @@ extern int main(int argc, char **argv) {
   if (sigaction(SIGUSR2, &sa, NULL) != 0) {
     Error("sigaction(2) failure");
   }
+
+  /* 親プロセス(monitor)停止で自動停止 */
+  prctl(PR_SET_PDEATHSIG, SIGHUP);
 
   stdout_path = getenv("WFC_DEBUG_STDOUT_PATH");
   if (stdout_path != NULL) {


### PR DESCRIPTION
* #238 でmonitorについてSIGUSR1でStopSystemを呼ぶよう修正したが、この影響でsystemctl restart jma-receiptをした場合にmonitorが起動しなくなった。
    * systemctrl stop jma-receipt && sleep 5 && systemctrl start jma-receiptなら動作する
```
Mar 26 13:21:55 xenial51 systemd[1]: Stopped User Manager for UID 123.
Mar 26 13:21:55 xenial51 systemd[1]: Removed slice User Slice of orca.
Mar 26 13:21:55 xenial51 jma-receipt[31159]:  * Starting monitor:
Mar 26 13:21:55 xenial51 jma-receipt[31159]:    ...fail!
Mar 26 13:21:58 xenial51 jma-receipt[31159]:  monitor.
Mar 26 13:21:58 xenial51 systemd[1]: Started LSB: jma-receipt server deamons.
Mar 26 13:21:59 xenial51 panda/monitor[30925]: stop system
Mar 26 13:21:59 xenial51 panda/monitor[30925]: wfc restart count:1
Mar 26 13:21:59 xenial51 panda/monitor[30925]: exit system
```
    * どうもstart時に前のmonitorが動作していると起動できない(systemdかstart-stop-daemonの影響?)
* 方針を変更してSIGUSR1で直ちにmonitorを停止し、aps、wfc、dbredirectorにprctlをセットするようにした。