### PR TITLE
XMLIO2::XMLOPEN,XMLCLOSEの廃止

### DIFF
--- a/dblib/XMLIO2.c
+++ b/dblib/XMLIO2.c
@@ -324,20 +324,6 @@ static ValueStruct *_Write(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
   return ret;
 }
 
-static ValueStruct *_Open(DBG_Struct *dbg, DBCOMM_CTRL *ctrl, RecordStruct *rec,
-                          ValueStruct *args) {
-  fprintf(stderr,"XMLOPEN: don't use this function.deprecated\n");
-  ctrl->rc = MCP_OK;
-  return NULL;
-}
-
-static ValueStruct *_Close(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
-                           RecordStruct *rec, ValueStruct *args) {
-  fprintf(stderr,"XMLCLOSE: don't use this function.deprecated\n");
-  ctrl->rc = MCP_OK;
-  return NULL;
-}
-
 extern ValueStruct *XML_BEGIN(DBG_Struct *dbg, DBCOMM_CTRL *ctrl) {
   return (NULL);
 }
@@ -353,10 +339,8 @@ static DB_OPS Operations[] = {
     {"DBSTART", (DB_FUNC)XML_BEGIN},
     {"DBCOMMIT", (DB_FUNC)XML_END},
     /*	table operations	*/
-    {"XMLOPEN", _Open},
     {"XMLREAD", _Read},
     {"XMLWRITE", _Write},
-    {"XMLCLOSE", _Close},
 
     {NULL, NULL}};
 


### PR DESCRIPTION
* #168の対応
* scan-buildでエラーがないこと
* XMLIO2の単体テストでXMLREAD、XMLWRITEの動作を確認
    * https://github.com/yusukemihara/PANDA-SAMPLE/tree/master/cobol%2Bterm/xmlio2_3