### PR TITLE
APIの場合でもセッションの一時ディレクトリを作成する

### DIFF
--- a/aps/MONFUNC.c
+++ b/aps/MONFUNC.c
@@ -135,15 +135,12 @@ static int MonGLFunc(ValueStruct *mcp) {
 
 static int _MONFUNC(char *mcpdata, char *data, ValueStruct **retval) {
   ValueStruct *mcp;
-  ValueStruct *audit;
   char *func;
   int ret;
 
   *retval = NULL;
   mcp = UnPackMCP(mcpdata);
 
-  audit = ThisEnv->auditrec->value;
-  InitializeValue(audit);
   func = ValueStringPointer(GetItemLongName(mcp, "func"));
   if (!strcmp(func, "PUTWINDOW")) {
     ret = MonGLFunc(mcp);

--- a/include/struct.h
+++ b/include/struct.h
@@ -323,7 +323,6 @@ typedef struct {
   char *DBMasterAuth;
   size_t cLD, cBD, cDBD, stacksize;
   SysData_Struct *sysdata;
-  RecordStruct *auditrec;
   RecordStruct *mcprec;
   RecordStruct *linkrec;
   char *InitialLD;


### PR DESCRIPTION
## 概要

#240 対応

* オンプレではAPIの場合はセッションの一時ディレクトリは作成していなかったが、クラウドにあわせて一時ディレクトリを作成するようにした。

## 動作確認

以下の単体テスト(DB+画面、API)で動作確認

* https://github.com/yusukemihara/PANDA-SAMPLE/tree/master/cobol%2Bterm/dbtest51
    * apsをvalgrindで確認しエラーがないことを確認
* https://github.com/yusukemihara/PANDA-SAMPLE/tree/master/cobol%2Bterm/xmlio2_3
    * scan-buildをパス