### PR TITLE
マルチフェッチ対応

### DIFF
--- a/aps/MONFUNC.c
+++ b/aps/MONFUNC.c
@@ -74,7 +74,6 @@ static void CTRLtoMCP(ValueStruct *mcp, DBCOMM_CTRL *ctrl) {
   strcpy(ValueStringPointer(GetItemLongName(mcp, "db.pathname")), ctrl->pname);
   SetValueInteger(GetItemLongName(mcp, "rc"), ctrl->rc);
   SetValueInteger(GetItemLongName(mcp, "db.rcount"), ctrl->rcount);
-  SetValueInteger(GetItemLongName(mcp, "db.limit"), ctrl->limit);
 }
 
 static void MCPtoCTRL(DBCOMM_CTRL *ctrl, ValueStruct *mcp) {
@@ -86,9 +85,7 @@ static void MCPtoCTRL(DBCOMM_CTRL *ctrl, ValueStruct *mcp) {
           SIZE_USER);
   strncpy(ctrl->term, ValueStringPointer(GetItemLongName(mcp, "dc.term")),
           SIZE_TERM);
-  if (ValueInteger(GetItemLongName(mcp, "version")) == 2) {
-    ctrl->limit = ValueInteger(GetItemLongName(mcp, "db.limit"));
-  }
+  ctrl->limit = ValueInteger(GetItemLongName(mcp, "db.limit"));
   if (!IsDBOperation(ctrl->func)) {
     rname = ValueStringPointer(GetItemLongName(mcp, "db.table"));
     SetDBCTRLRecord(ctrl, rname);

--- a/aps/aps_main.c
+++ b/aps/aps_main.c
@@ -112,6 +112,8 @@ static void InitSystem(char *name) {
   TextSize = ThisLD->textsize;
   if (ThisEnv->mcprec != NULL) {
     InitializeValue(ThisEnv->mcprec->value);
+    /* デフォルトフェッチ件数を100に設定 */
+    SetValueInteger(GetItemLongName(ThisEnv->mcprec->value, "db.limit"), 100);
   }
   if (ThisEnv->linkrec != NULL) {
     InitializeValue(ThisEnv->linkrec->value);

--- a/aps/handler.c
+++ b/aps/handler.c
@@ -237,7 +237,6 @@ static void CallBefore(WindowBind *bind, ProcessNode *node) {
   SetValueString(GetItemLongName(mcp, "dc.dbstatus"),
                  DBSTATUS[(int)node->dbstatus], NULL);
   SetValueInteger(GetItemLongName(mcp, "db.rcount"), 0);
-  SetValueInteger(GetItemLongName(mcp, "db.limit"), 1);
   node->thisscrrec = bind->rec;
 
   /* SCREEN_NULLを除去  */

--- a/dblib/PostgreSQL.c
+++ b/dblib/PostgreSQL.c
@@ -770,13 +770,11 @@ static ValueStruct *PGresToValueFetch(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
     ctrl->rc = MCP_EOF;
     return ret;
   }
-  if (count < ctrl->limit && (count - 1) < fetch_index) {
+  ret = _PGresToValue(dbg, fetch_result, fetch_index, val);
+  fetch_index += 1;
+  if (fetch_index >= count) {
+    /* refetch */
     ClearFetchResult();
-    ctrl->rc = MCP_EOF;
-    return ret;
-  } else {
-    ret = _PGresToValue(dbg, fetch_result, fetch_index, val);
-    fetch_index += 1;
   }
   return ret;
 }


### PR DESCRIPTION
* #236
* scan-buildでエラーにならないこと
* 単体テスト(https://github.com/montsuqi/panda-samples)のvalgrind実行で初期化エラーが一部発生するが原因不明(以前からあるのではないか)
    * タイミングとしては初回のトランザクション実行時のCOBOLモジュールのSCR領域の設定
```
==2249== Memcheck, a memory error detector
==2249== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2249== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==2249== Command: aps test1
==2249==
==2249== Conditional jump or move depends on uninitialised value(s)
==2249==    at 0x547CB67: StringC2Cobol (cobolvalue.c:63)
==2249==    by 0x547D658: OpenCOBOL_PackValue (OpenCOBOL.c:288)
==2249==    by 0x547D888: OpenCOBOL_PackValue (OpenCOBOL.c:324)
==2249==    by 0x547D888: OpenCOBOL_PackValue (OpenCOBOL.c:324)
==2249==    by 0x103B498F: PutApplication (OpenCOBOL.c:76)
==2249==    by 0x103B498F: _ExecuteProcess (OpenCOBOL.c:117)
==2249==    by 0x40478C: ExecuteProcess (handler.c:417)
==2249==    by 0x40325D: ExecuteServer (aps_main.c:307)
==2249==    by 0x40325D: main (aps_main.c:417)
==2249==
```