### PR TITLE
Fix 253 254

### DIFF
--- a/glserver/glserver.c
+++ b/glserver/glserver.c
@@ -85,7 +85,7 @@ static void SetDefault(void) {
   PortNumber = PORT_GLTERM;
   PortSysData = SYSDATA_PORT;
   Directory = "./directory";
-  Back = 5;
+  Back = 512;
   AuthURL = "glauth://localhost:" PORT_GLAUTH;
   fAPI = FALSE;
   fDebug = FALSE;

--- a/tools/monitor.c
+++ b/tools/monitor.c
@@ -60,6 +60,7 @@ static int SesNum;
 static Bool fGlserver;
 static Bool fGlSSL;
 static Bool fVerifyPeer;
+static int BackNum;
 static char *GlAuth;
 static char *GlCert;
 static char *GlCAfile;
@@ -107,6 +108,7 @@ static ARG_TABLE option[] = {
      "root of temporary directory"},
 
     {"glserver", BOOLEAN, TRUE, (void *)&fGlserver, "start glserver"},
+    {"back", INTEGER, TRUE, (void *)&BackNum, "socket backlog number"},
     {"glauth", STRING, TRUE, (void *)&GlAuth, "glserver authentication"},
     {"glssl", BOOLEAN, TRUE, (void *)&fGlSSL, "use ssl connection"},
     {"verifypeer", BOOLEAN, TRUE, (void *)&fVerifyPeer, "verify peer"},
@@ -204,6 +206,7 @@ static void SetDefault(void) {
   fGlserver = FALSE;
   fGlSSL = FALSE;
   fVerifyPeer = FALSE;
+  BackNum = 512;
   GlAuth = NULL;
   GlCert = NULL;
   GlCAfile = NULL;
@@ -302,6 +305,11 @@ static void InitGlserver(void) {
       argv[argc++] = "-verifypeer";
     }
   }
+  if (BackNum < 5) {
+    BackNum = 5;
+  }
+  argv[argc++] = "-back";
+  argv[argc++] = IntStrDup(BackNum);
 
   proc->argc = argc;
   argv[argc++] = NULL;


### PR DESCRIPTION
* monitor起動オプションにglserver -backオプションを追加する
* glserverの-backオプション(listenのbacklog)のデフォルトを5から512に増やす