### PR TITLE
ubuntu20.04対応(2)

### DIFF
--- a/aps/dbstub_main.c
+++ b/aps/dbstub_main.c
@@ -56,6 +56,11 @@ static char AppName[128];
 static char *BD_Name;
 static BatchBind *Bind;
 
+/* <deprecate> */
+static Bool NopBool;
+static int NopInt;
+/* </deprecate> */
+
 static void InitData(char *name) {
   InitDirectory();
   SetUpDirectory(Directory, "", name, "", P_ALL);
@@ -149,6 +154,17 @@ static ARG_TABLE option[] = {
     {"pass", STRING, TRUE, (void *)&DB_Pass, "パスワード"},
     {"bd", STRING, TRUE, (void *)&BD_Name, "BD定義名"},
 
+/* <deprecate> */
+    {"nocheck", BOOLEAN, TRUE, (void *)&NopBool,
+     "dbredirectorの起動をチェックしない"},
+    {"noredirect", BOOLEAN, TRUE, (void *)&NopBool,
+     "dbredirectorを使わない"},
+    {"maxretry", INTEGER, TRUE, (void *)&NopInt,
+     "dbredirector送信の再試行数を指定する"},
+    {"retryint", INTEGER, TRUE, (void *)&NopInt,
+     "dbredirector送信の再試行の間隔を指定する(秒)"},
+/* </deprecate> */
+
     {NULL, 0, FALSE, NULL, NULL}};
 
 static void SetDefault(void) {
@@ -165,6 +181,11 @@ static void SetDefault(void) {
   DB_Name = DB_User;
   BD_Name = NULL;
   CommandParameter = "";
+
+/* <deprecate> */
+  NopBool = FALSE;
+  NopInt = 1;
+/* </deprecate> */
 }
 
 extern int main(int argc, char **argv) {

--- a/dblib/Shell.c
+++ b/dblib/Shell.c
@@ -150,6 +150,7 @@ static ValueStruct *_DBCOMMIT(DBG_Struct *dbg, DBCOMM_CTRL *ctrl) {
   int rc;
   char **cmdv;
 
+  LBS_EmitEnd(dbg->misc);
   setenv("GINBEE_CUSTOM_BATCH_REPOS_NAMES", LBS_Body(dbg->misc), 1);
 
   cmdv = (char **)dbg->conn;

--- a/libs/DIparser.c
+++ b/libs/DIparser.c
@@ -713,14 +713,12 @@ static void ParDBGROUP(CURFILE *in, char *name) {
       break;
     case T_REDIRECT:
       if (GetSymbol == T_SCONST) {
-        fprintf(stderr,"T_REDIRECT deprecated\n");
       } else {
         ParError("invalid redirect group");
       }
       break;
     case T_PRIORITY:
       if (GetSymbol == T_ICONST) {
-        fprintf(stderr,"T_PRIORITY deprecated\n");
       } else {
         ParError("priority invalid");
       }


### PR DESCRIPTION
* ￼変数名変更時の変更漏れでapsがDBCOMMITでSegVするのを修正
* dbstubのオプションを廃止から廃止予定にした(日レセ側の対応が必要なため)
* scan-buildでエラーがないことを確認