### PR TITLE
証明書更新時にパスフレーズをファイル保存する

### DIFF
--- a/glclient/certificate.c
+++ b/glclient/certificate.c
@@ -148,6 +148,8 @@ void setupNewCert(Certificate *cert) {
   cert->new_cert_name = g_build_filename(cert->cert_dir, buf, NULL);
   strftime(buf, sizeof(buf), "%Y%m%d%H%M%S.pem", localtime(&now));
   cert->new_key_name = g_build_filename(cert->cert_dir, buf, NULL);
+  strftime(buf, sizeof(buf), "%Y%m%d%H%M%S.pass", localtime(&now));
+  cert->new_pass_name = g_build_filename(cert->cert_dir, buf, NULL);
 }
 
 Certificate *initCertificate() {
@@ -283,6 +285,8 @@ void decode_p12(Certificate *cert) {
   }
   PEM_write_PrivateKey(fp,pkey,pCipher,(unsigned char*)cert->NewCertPass,(int)strlen(cert->NewCertPass),NULL,NULL);
   fclose(fp);
+
+  g_file_set_contents(cert->new_pass_name, cert->NewCertPass, strlen(cert->NewCertPass), NULL);
 }
 
 void save_cert_config(Certificate *cert) {

--- a/glclient/certificate.h
+++ b/glclient/certificate.h
@@ -7,6 +7,7 @@ typedef struct {
   gchar *new_p12_name;
   gchar *new_cert_name;
   gchar *new_key_name;
+  gchar *new_pass_name;
   gchar *APIDomain;
   const char *CertFile;
   const char *CertKeyFile;


### PR DESCRIPTION
* 証明書更新時にパスフレーズファイルが作成されているのを確認
* パスフレーズファイルのパスフレーズでp12を展開できることを確認