### PR TITLE
glserverをtransfer-encoding:chunkedに対応

### DIFF
--- a/glclient/protocol.c
+++ b/glclient/protocol.c
@@ -187,7 +187,7 @@ size_t HeaderPostBLOB(void *ptr, size_t size, size_t nmemb, void *userdata) {
 
 char *REST_PostBLOB(GLProtocol *ctx, LargeByteString *lbs) {
   struct curl_slist *headers = NULL;
-  char *oid, url[SIZE_URL_BUF + 1], clength[256], buf[256];
+  char *oid, url[SIZE_URL_BUF + 1], buf[256];
   long http_code;
   CURLcode res;
 
@@ -203,9 +203,7 @@ char *REST_PostBLOB(GLProtocol *ctx, LargeByteString *lbs) {
   headers =
       curl_slist_append(headers, "Content-Type: application/octet-stream");
   headers =
-      curl_slist_append(headers, "Transfer-Encoding: identity");
-  snprintf(clength, sizeof(clength), "Content-Length: %ld", LBS_Size(lbs));
-  headers = curl_slist_append(headers, clength);
+      curl_slist_append(headers, "Transfer-Encoding: chunked");
 
   LBS_SetPos(lbs, 0);
 
@@ -424,10 +422,12 @@ static json_object *JSONRPC(GLProtocol *ctx, int type, json_object *obj) {
            PACKAGE_DATE);
   headers = curl_slist_append(headers, buf);
   headers = curl_slist_append(headers, "Content-Type: application/json");
+#if 0
   snprintf(buf, sizeof(buf), "Content-Length: %ld", ctx->ReqSize);
   headers = curl_slist_append(headers, buf);
+#endif
   headers = curl_slist_append(headers, "Expect:");
-  headers = curl_slist_append(headers, "Transfer-Encoding: identity");
+  headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
   if (ctx->fSSO) {
     headers = curl_slist_append(headers, "X-Support-SSO: 1");
   }

--- a/glclient/protocol.c
+++ b/glclient/protocol.c
@@ -187,7 +187,7 @@ size_t HeaderPostBLOB(void *ptr, size_t size, size_t nmemb, void *userdata) {
 
 char *REST_PostBLOB(GLProtocol *ctx, LargeByteString *lbs) {
   struct curl_slist *headers = NULL;
-  char *oid, url[SIZE_URL_BUF + 1], clength[256], buf[256];
+  char *oid, url[SIZE_URL_BUF + 1], buf[256];
   long http_code;
   CURLcode res;
 
@@ -202,10 +202,6 @@ char *REST_PostBLOB(GLProtocol *ctx, LargeByteString *lbs) {
   headers = curl_slist_append(headers, buf);
   headers =
       curl_slist_append(headers, "Content-Type: application/octet-stream");
-  headers =
-      curl_slist_append(headers, "Transfer-Encoding: identity");
-  snprintf(clength, sizeof(clength), "Content-Length: %ld", LBS_Size(lbs));
-  headers = curl_slist_append(headers, clength);
 
   LBS_SetPos(lbs, 0);
 
@@ -424,10 +420,7 @@ static json_object *JSONRPC(GLProtocol *ctx, int type, json_object *obj) {
            PACKAGE_DATE);
   headers = curl_slist_append(headers, buf);
   headers = curl_slist_append(headers, "Content-Type: application/json");
-  snprintf(buf, sizeof(buf), "Content-Length: %ld", ctx->ReqSize);
-  headers = curl_slist_append(headers, buf);
   headers = curl_slist_append(headers, "Expect:");
-  headers = curl_slist_append(headers, "Transfer-Encoding: identity");
   if (ctx->fSSO) {
     headers = curl_slist_append(headers, "X-Support-SSO: 1");
   }

--- a/glclient/protocol.c
+++ b/glclient/protocol.c
@@ -187,7 +187,7 @@ size_t HeaderPostBLOB(void *ptr, size_t size, size_t nmemb, void *userdata) {
 
 char *REST_PostBLOB(GLProtocol *ctx, LargeByteString *lbs) {
   struct curl_slist *headers = NULL;
-  char *oid, url[SIZE_URL_BUF + 1], buf[256];
+  char *oid, url[SIZE_URL_BUF + 1], clength[256], buf[256];
   long http_code;
   CURLcode res;
 
@@ -202,6 +202,10 @@ char *REST_PostBLOB(GLProtocol *ctx, LargeByteString *lbs) {
   headers = curl_slist_append(headers, buf);
   headers =
       curl_slist_append(headers, "Content-Type: application/octet-stream");
+  headers =
+      curl_slist_append(headers, "Transfer-Encoding: identity");
+  snprintf(clength, sizeof(clength), "Content-Length: %ld", LBS_Size(lbs));
+  headers = curl_slist_append(headers, clength);
 
   LBS_SetPos(lbs, 0);
 
@@ -420,7 +424,10 @@ static json_object *JSONRPC(GLProtocol *ctx, int type, json_object *obj) {
            PACKAGE_DATE);
   headers = curl_slist_append(headers, buf);
   headers = curl_slist_append(headers, "Content-Type: application/json");
+  snprintf(buf, sizeof(buf), "Content-Length: %ld", ctx->ReqSize);
+  headers = curl_slist_append(headers, buf);
   headers = curl_slist_append(headers, "Expect:");
+  headers = curl_slist_append(headers, "Transfer-Encoding: identity");
   if (ctx->fSSO) {
     headers = curl_slist_append(headers, "X-Support-SSO: 1");
   }

--- a/glserver/http.c
+++ b/glserver/http.c
@@ -283,7 +283,7 @@ badio:
   return 0;
 }
 
-static void TryRecvSize(HTTP_REQUEST *req,size_t size) {
+static void RecvBytes(HTTP_REQUEST *req,size_t size) {
   size_t parsed,remain;
   while(1) {
     parsed = req->head - req->buf;
@@ -452,14 +452,14 @@ static void ParseReqBodyContentLength(HTTP_REQUEST *req,const char *value)
     Message("invalid Content-Length:%s", value);
     return;
   }
-  TryRecvSize(req,body_size);
+  RecvBytes(req,body_size);
   memcpy(req->body,req->head,body_size);
   req->body_size = body_size;
   req->head += body_size;
 }
 
 static void CheckCRLF(HTTP_REQUEST *req) {
-  TryRecvSize(req,2);
+  RecvBytes(req,2);
   if (*(req->head) != 0x0d || *(req->head+1) != 0x0a) {
     req->status = HTTP_BAD_REQUEST;
     Message("CRLF needed; %02x,%02x",*(req->head),*(req->head+1));
@@ -469,7 +469,7 @@ static void CheckCRLF(HTTP_REQUEST *req) {
 }
 
 static void GetChunk(HTTP_REQUEST *req,size_t size) {
-  TryRecvSize(req,size);
+  RecvBytes(req,size);
   memcpy(req->body+req->body_size,req->head,size);
   req->head += size;
   req->body_size += size;


### PR DESCRIPTION
### glserverの transfer-encoding:chunked 対応
* content-lengthもしくはchunked encodingに対応
* ubuntu 20.04のlibcurl(glclient2)でデフォルトでtransfer-encoding:chunkedとなるため
    * transfer-encoding: identityにすればオンプレ接続はできるが、クラウドには接続できなくなった
    * そもそもtransfer-encodingとcontent-lengthは排他的なヘッダーであるため

### glclient2のHTTPヘッダ修正

* glclient2はcontent-lengthをやめてchunkedのみにするようにした
    * 20.04 glserverとクラウドに接続できることを確認
* 日レセ5.1以前のglserverはchunkedに対応していないので5.2のglclient2は5.1のglserverに接続できない
    * 日レセ5.1 5.0のglserverもchunked対応するかもしれない