### PR TITLE
glclient2の一時ディレクトリ初期化時にディレクトリルートを再作成していた

### DIFF
--- a/glclient/tempdir.c
+++ b/glclient/tempdir.c
@@ -52,12 +52,12 @@ void InitTempDir() {
 
   RootDir = g_build_filename(g_get_home_dir(), GL_ROOT_DIR, NULL);
   dir = g_build_filename(RootDir, "tmp", NULL);
-  MakeDir(dir, 0700);
+  mkdir_p(dir, 0700);
   rm_r_old(dir, ELAPSED);
   uuid_generate(u);
   uuid_unparse(u, buf);
   TempDir = g_build_filename(dir, buf, NULL);
-  MakeDir(TempDir, 0700);
+  mkdir_p(TempDir, 0700);
   g_free(dir);
   fprintf(stderr, "tempdir: %s\n", TempDir);
 }


### PR DESCRIPTION
* クライアントを複数起動すると一時ディレクトリが削除され起動しないことがあった
* 以前はrm_r()の不具合でディレクトリが削除されず問題が露呈していなかった
* MakeDir()はmkdir_p_clean()などにすると良いかも知れない(libmondai)