### PR TITLE
イベントログフォーマット及びログビューア修正

### DIFF
--- a/glclient/callbacks.c
+++ b/glclient/callbacks.c
@@ -181,7 +181,7 @@ extern void send_event(GtkWidget *widget, char *event) {
     Info("[send_event] "
          "total:%lums "
          "make_event_data:%lums "
-         "rpc_total:%lu "
+         "rpc_total:%lums "
          "server_total:%lums "
          "server_app:%lums "
          "update_screen:%lums",

--- a/glclient/logviewer.c
+++ b/glclient/logviewer.c
@@ -139,6 +139,7 @@ static gboolean on_csv(GtkWidget *widget,void *data) {
       GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, GTK_STOCK_SAVE,
       GTK_RESPONSE_ACCEPT, NULL);
   gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
+  gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "out.csv");
   gtk_window_set_keep_above(GTK_WINDOW(dialog), TRUE);
   gtk_window_set_modal(GTK_WINDOW(dialog), TRUE);
 

--- a/glclient/logviewer.c
+++ b/glclient/logviewer.c
@@ -42,7 +42,7 @@
 static void update_list(GtkWidget *label,GtkWidget *list, const char *fname) {
   GtkListStore *model;
   GtkTreeIter iter;
-  GRegex *re1, *re2, *re3;
+  GRegex *re1,*re2,*re3;
   GMatchInfo *mi;
   FILE *fp;
   char buf[LINE_BUF_SIZE],*host,*datetime,*window,*widget,*event;
@@ -50,7 +50,7 @@ static void update_list(GtkWidget *label,GtkWidget *list, const char *fname) {
 
   re1 = g_regex_new("start_session (.*)",0,0,NULL);
   re2 = g_regex_new("(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}).*window\\:(.*) widget\\:(.*) event\\:(.*)",0,0,NULL);
-  re3 = g_regex_new("rpc_total\\:(\\d+) server_total\\:(\\d+)ms server_app\\:(\\d+)ms",0,0,NULL);
+  re3 = g_regex_new("rpc_total\\:(\\d+)(?:ms)? server_total\\:(\\d+)ms server_app\\:(\\d+)ms",0,0,NULL);
 
   model = (GtkListStore *)gtk_tree_view_get_model(GTK_TREE_VIEW(list));
   gtk_list_store_clear(model);


### PR DESCRIPTION
* イベントログの rpc_total:(\d+)ms のms部分が抜けていたので付与するよう修正
* イベントログ修正にあわせてログビューアのログパーサを新旧いずれもパースできるよう修正
* CSV出力時のデフォルトファイル名をout.csvに設定
* scan-buildでエラーがないことを確認 