### PR TITLE
Fix 271 monblob保持期限の変更および保持期限設定のdirectoryへの追加

### DIFF
--- a/dblib/MONBLOB.c
+++ b/dblib/MONBLOB.c
@@ -85,6 +85,8 @@ static ValueStruct *_ImportBLOB(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
   char *filename = NULL;
   char *content_type = NULL;
   int rc;
+  int _lifetype;
+  unsigned int lifetype = 1;
 
   mondbg = GetDBG_monsys();
   if ((val = GetItemLongName(args, "id")) != NULL) {
@@ -99,7 +101,15 @@ static ValueStruct *_ImportBLOB(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
   if ((val = GetItemLongName(args, "content_type")) != NULL) {
     content_type = ValueToString(val, dbg->coding);
   }
-  rid = monblob_import(mondbg, id, persist, filename, content_type, 1);
+  if ((val = GetItemLongName(args, "lifetype")) != NULL) {
+    _lifetype = ValueToInteger(val, dbg->coding);
+    if (_lifetype < 0) {
+      lifetype = 1;
+    } else {
+      lifetype = _lifetype;
+    }
+  }
+  rid = monblob_import(mondbg, id, persist, filename, content_type, lifetype);
   if ((rid != NULL) && (val = GetItemLongName(args, "id")) != NULL) {
     SetValueString(val, rid, dbg->coding);
     xfree(rid);

--- a/dblib/MONBLOB.c
+++ b/dblib/MONBLOB.c
@@ -102,7 +102,7 @@ static ValueStruct *_ImportBLOB(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
     content_type = ValueToString(val, dbg->coding);
   }
   if ((val = GetItemLongName(args, "lifetype")) != NULL) {
-    _lifetype = ValueToInteger(val, dbg->coding);
+    _lifetype = ValueToInteger(val);
     if (_lifetype < 0) {
       lifetype = 1;
     } else {

--- a/dblib/bytea.c
+++ b/dblib/bytea.c
@@ -394,7 +394,7 @@ static Bool monblob_expire(DBG_Struct *dbg) {
            "DELETE FROM %s WHERE (lifetype = 0 AND (now() > importtime + "
            "CAST('%d days' AS INTERVAL))) OR (lifetype = 1 AND (now() > "
            "importtime + CAST('%d days' AS INTERVAL)));",
-           MONBLOB, BLOBEXPIRE, MONBLOBEXPIRE);
+           MONBLOB, ThisEnv->blobexpire, ThisEnv->monblobexpire);
   rc = ExecDBOP(dbg, sql);
   xfree(sql);
   return (rc == MCP_OK);

--- a/dblib/bytea.h
+++ b/dblib/bytea.h
@@ -23,7 +23,7 @@
 #include "dblib.h"
 #define MONBLOB "monblob"
 #define BLOBEXPIRE 2
-#define MONBLOBEXPIRE 50
+#define MONBLOBEXPIRE 7
 #define SEQMONBLOB "seqmonblob"
 
 #define MON_LIFE_SHORT 0

--- a/dblib/bytea.h
+++ b/dblib/bytea.h
@@ -22,8 +22,6 @@
 
 #include "dblib.h"
 #define MONBLOB "monblob"
-#define BLOBEXPIRE 2
-#define MONBLOBEXPIRE 7
 #define SEQMONBLOB "seqmonblob"
 
 #define MON_LIFE_SHORT 0

--- a/include/struct.h
+++ b/include/struct.h
@@ -341,6 +341,8 @@ typedef struct {
 
   char *DBMasterLogDBName;
   char *CryptoPass;
+  int blobexpire;
+  int monblobexpire;
 } DI_Struct;
 
 typedef struct {

--- a/libs/DIparser.c
+++ b/libs/DIparser.c
@@ -106,6 +106,8 @@
 
 #define T_INITIAL_LD (T_YYBASE + 54)
 #define T_CRYPTOPASS (T_YYBASE + 55)
+#define T_BLOBEXPIRE (T_YYBASE + 56)
+#define T_MONBLOBEXPIRE (T_YYBASE + 57)
 
 static TokenTable tokentable[] = {{"ld", T_LD},
                                   {"initial_ld", T_INITIAL_LD},
@@ -160,6 +162,8 @@ static TokenTable tokentable[] = {{"ld", T_LD},
                                   {"dbmaster", T_DBMASTER},
                                   {"auditlog", T_AUDITLOG},
                                   {"sumcheck", T_SUMCHECK},
+                                  {"blobexpire", T_BLOBEXPIRE},
+                                  {"monblobexpire", T_MONBLOBEXPIRE},
                                   {"", 0}};
 
 static GHashTable *Reserved;
@@ -916,6 +920,8 @@ static DI_Struct *NewEnv(char *name) {
   env->DBMasterLogDBName = NULL;
   env->InitialLD = NULL;
   env->CryptoPass = NULL;
+  env->blobexpire = 2;
+  env->monblobexpire = 7;
 
   return (env);
 }
@@ -1091,6 +1097,20 @@ static DI_Struct *ParDI(CURFILE *in, char *ld, char *bd, char *db,
     case T_INITIAL_LD:
       GetName;
       ThisEnv->InitialLD = StrDup(ComSymbol);
+      break;
+    case T_BLOBEXPIRE:
+      if (GetSymbol == T_ICONST) {
+        ThisEnv->blobexpire = ComInt;
+      } else {
+        ParError("invalid blobexpire");
+      }
+      break;
+    case T_MONBLOBEXPIRE:
+      if (GetSymbol == T_ICONST) {
+        ThisEnv->blobexpire = ComInt;
+      } else {
+        ParError("invalid blobexpire");
+      }
       break;
     case T_BD:
       if (GetSymbol == '{') {

--- a/libs/DIparser.c
+++ b/libs/DIparser.c
@@ -1107,7 +1107,7 @@ static DI_Struct *ParDI(CURFILE *in, char *ld, char *bd, char *db,
       break;
     case T_MONBLOBEXPIRE:
       if (GetSymbol == T_ICONST) {
-        ThisEnv->blobexpire = ComInt;
+        ThisEnv->monblobexpire = ComInt;
       } else {
         ParError("invalid blobexpire");
       }


### PR DESCRIPTION
* #271 の対応
* scan-buildパス
* directoryのmonblobexpire、blobexpire設定が反映されること
* API 100並列 10分実行でエラーが発生しないこと
* /usr/lib/panda/bin/monblobコマンドでmonblobに登録できること
* monblobテーブルのimporttimeを直接変更してmonblobexpire期間経過状態で対象のmonblobが削除されること