### PR TITLE
termthread RPC_PandaAPIでSIGABRTが発生する不具合修正

### DIFF
--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -863,13 +863,17 @@ static void RPC_PandaAPI(TermNode *term, json_object *obj) {
   data = Process(data);
   api = data->apidata;
 
-  res = MakeJSONResponseTemplate(obj);
-  NativeUnPackValue(NULL, LBS_Body(api->rec), rec->value);
-  buf = xmalloc(JSON_SizeValue(NULL, rec->value));
+  {
+    res = MakeJSONResponseTemplate(obj);
+    val = DuplicateValue(rec->value, FALSE);
+    NativeUnPackValue(NULL, LBS_Body(api->rec), val);
+    buf = xmalloc(JSON_SizeValue(NULL, val));
 
-  JSON_PackValue(NULL, buf, rec->value);
-  child = json_tokener_parse(buf);
-  xfree(buf);
+    JSON_PackValue(NULL, buf, val);
+    child = json_tokener_parse(buf);
+    xfree(buf);
+    FreeValueStruct(val);
+  }
 
   json_object_object_add(res, "result", child);
   json_object_object_add(res, "api_status", json_object_new_int(api->status));


### PR DESCRIPTION
### 概要

* #274 の対応
* wfc termthread RPC_PandaAPIでNativeUnpackValueする際にwfcプロセス共有のvaluestructに展開していた
* 複数スレッドが同時にNativeUnpackValueするとメモリ破壊が発生してdubble freeとなりSIGABRTが発生する可能性
* 他と同様にDuplicateValueしてからNativeUnpackValueすることでメモリ破壊を防ぐ

### 動作確認

* scan-buildのパス
* 日レセAPIを100並列10分間実行してSIGABRTが発生しないことを確認
    * ただ修正前のコードでも同様の試験でSIGABRTが発生しなかった
    * 元々1週間に1回から1日に1回の頻度なので再現率が低いのかも