### PR TITLE
ミドルウェア更新をアプリ側で把握するために環境変数MONBLOB_VERSION=1.0.0を設定する

### DIFF
--- a/dblib/MONBLOB.c
+++ b/dblib/MONBLOB.c
@@ -210,9 +210,16 @@ static ValueStruct *_DestroyBLOB(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
   return (ret);
 }
 
+extern ValueStruct *MONBLOB_DBOPEN(DBG_Struct *dbg, DBCOMM_CTRL *ctrl) {
+  dbg->dbstatus = DB_STATUS_CONNECT;
+  ctrl->rc = MCP_OK;
+  setenv("MONBLOB_VERSION",MONBLOB_VERSION,1);
+  return (NULL);
+}
+
 static DB_OPS Operations[] = {
     /*	DB operations		*/
-    {"DBOPEN", (DB_FUNC)_DBOPEN},
+    {"DBOPEN", (DB_FUNC)MONBLOB_DBOPEN},
     {"DBDISCONNECT", (DB_FUNC)_DBDISCONNECT},
     {"DBSTART", (DB_FUNC)_DBSTART},
     {"DBCOMMIT", (DB_FUNC)_DBCOMMIT},

--- a/dblib/MONBLOB.c
+++ b/dblib/MONBLOB.c
@@ -210,16 +210,9 @@ static ValueStruct *_DestroyBLOB(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
   return (ret);
 }
 
-extern ValueStruct *MONBLOB_DBOPEN(DBG_Struct *dbg, DBCOMM_CTRL *ctrl) {
-  dbg->dbstatus = DB_STATUS_CONNECT;
-  ctrl->rc = MCP_OK;
-  setenv("MONBLOB_VERSION",MONBLOB_VERSION,1);
-  return (NULL);
-}
-
 static DB_OPS Operations[] = {
     /*	DB operations		*/
-    {"DBOPEN", (DB_FUNC)MONBLOB_DBOPEN},
+    {"DBOPEN", (DB_FUNC)_DBOPEN},
     {"DBDISCONNECT", (DB_FUNC)_DBDISCONNECT},
     {"DBSTART", (DB_FUNC)_DBSTART},
     {"DBCOMMIT", (DB_FUNC)_DBCOMMIT},
@@ -238,6 +231,7 @@ static DB_Primitives Core = {
 };
 
 extern DB_Func *InitMONBLOB(void) {
+  setenv("MONBLOB_VERSION",MONBLOB_VERSION,1);
   return (
       EnterDB_Function("MONBLOB", Operations, DB_PARSER_NULL, &Core, "", ""));
 }

--- a/dblib/bytea.h
+++ b/dblib/bytea.h
@@ -23,6 +23,7 @@
 #include "dblib.h"
 #define MONBLOB "monblob"
 #define SEQMONBLOB "seqmonblob"
+#define MONBLOB_VERSION "1.0.0"
 
 #define MON_LIFE_SHORT 0
 #define MON_LIFE_LONG 1


### PR DESCRIPTION
* monblob_lifetype変更の有無をCOBOLアプリから把握するために環境変数MONBLOB_VERSION=1.0.0を設定する
    * 変更後pandaだったらlifetype=3を設定するといった利用法を想定
* MIDDLEWARE_VERSION環境変数もあるがクラウド版、オンプレ版両方修正が必要のため、MONBLOB_VERSIONを設定することとした
* scan-buildでエラーがないことを確認
* panda-samplesでCOBOLアプリからMONBLOB_VERSIONを取得できることを確認