### PR TITLE
MON_LIFE_ETERNAL=2を廃止して整理、lifetypeに関わらず最大50日で削除するよう変更

### DIFF
--- a/dblib/bytea.c
+++ b/dblib/bytea.c
@@ -393,16 +393,21 @@ static Bool monblob_expire(DBG_Struct *dbg) {
   snprintf(sql, sql_len,
            "DELETE FROM %s "
            "WHERE "
-           "  (lifetype = 0 AND "
+           "  ((now() > importtime + CAST('%d days' AS INTERVAL))) "
+           "OR "
+           "  (lifetype = %d AND "
            "    (now() > importtime + CAST('%d days' AS INTERVAL))) "
            "OR "
-           "  (lifetype = 1 AND "
+           "  (lifetype = %d AND "
            "    (now() > importtime + CAST('%d days' AS INTERVAL))) "
            "OR "
-           "  (lifetype = 3 AND "
+           "  (lifetype = %d AND "
            "    (now() > importtime + CAST('%d days' AS INTERVAL)));",
-           MONBLOB, ThisEnv->blob_expire, ThisEnv->monblob_expire,
-           ThisEnv->monblob_expire_long);
+           MONBLOB,
+           MONBLOB_FINAL_EXPIRE,
+           MON_LIFE_SHORT, ThisEnv->blob_expire,
+           MON_LIFE_LONG, ThisEnv->monblob_expire,
+           MON_LIFE_LONG_LONG, ThisEnv->monblob_expire_long);
   rc = ExecDBOP(dbg, sql);
   xfree(sql);
   return (rc == MCP_OK);

--- a/dblib/bytea.h
+++ b/dblib/bytea.h
@@ -27,8 +27,9 @@
 
 #define MON_LIFE_SHORT 0
 #define MON_LIFE_LONG 1
-#define MON_LIFE_ETERNAL 2
-#define MON_LIFE_LONG_LONG 3
+#define MON_LIFE_LONG_LONG 2
+
+#define MONBLOB_FINAL_EXPIRE 50
 
 typedef struct _monblob_struct {
   char *id;


### PR DESCRIPTION
* MON_LIFE_ETERNAL=2=永久保存を廃止
* MON_LIFE_LONG_LONG=3->2に変更
* lifetypeに関わらずMONBLOB_FINAL_EXPIRE=50daysで削除するように
* scan-buildでエラーがないことを確認
* panda-samplesの単体テストで各LIFETYPEの削除が正しく動作することを確認
    * 2日経過していないMON_LIFE_SHORTのレコードが削除されない
    * 2日以上経過したMON_LIFE_SHORTのレコードが削除される 
    * 7日経過していないMON_LIFE_LONGのレコードが削除されない
    * 7日以上経過したMON_LIFE_LONGのレコードが削除される 
    * 50日経過していないMON_LIFE_LONG_LONGのレコードが削除されない
    * 50日以上経過したMON_LIFE_LONG_LONGのレコードが削除される 
    * 50日以上経過したlifetype=5(通常作成されない)のレコードが削除される 

