### PR TITLE
親プロセスのglserverが残るのを修正

### DIFF
--- a/glserver/glserver.c
+++ b/glserver/glserver.c
@@ -103,6 +103,7 @@ static void SetDefault(void) {
 static void StopProcess(int ec) {
   //kill process group
   kill(0,SIGINT);
+  exit(0);
 }
 
 static void ExecuteServer(void) {


### PR DESCRIPTION
* glserverはtcp acceptする親プロセスとクライアント処理を行う子プロセスという構成
* monitorからの停止シグナル(SIGHUP)受信時に子プロセスにSIGINTを送って停止させていたが、親プロセスは残っていた
* 日レセ5.1ではinit.dスクリプト内でkillall glserverとしていたため気づかなかった
* 日レセ5.2でsystemd以降してglserverが残っているのに気づいた