### PR TITLE
APIではセッション一時ディレクトリを直ちに削除

### DIFF
--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -132,7 +132,12 @@ static guint FreeWindowTable(char *name, void *data, void *dummy) {
 }
 
 static void FreeSessionData(SessionData *data) {
-  if (data->type != SESSION_TYPE_API) {
+  /* APIの場合は一時ディレクトリを削除 */
+  if (data->type == SESSION_TYPE_API) {
+    if (!rm_r(data->hdr->tempdir)) {
+      Error("cannot remove api session tempdir %s",data->hdr->tempdir);
+    }
+  } else {
     MessageLogPrintf("session end %s [%s@%s] %s", data->hdr->uuid,
                      data->hdr->user, data->hdr->host, data->agent);
   }


### PR DESCRIPTION
* 以前の修正でクラウドに合わせてAPIでも一時ディレクトリを作成するようにした
* -> APIアクセスのたびに一時ディレクトリが作成されて残るので毎秒数回APIアクセスするような場合、大量のディレクトリが作成される
    * 1日以上経過した一時ディレクトリは削除されるがそれでも数万程度は作成されうる

* scan-buildでのチェックをパス
* https://github.com/montsuqi/panda-samples/tree/master/xmlio2 で動作確認
    * APIリクエスト・レスポンスが正しい
    * /tmp/panda_root以下にディレクトリが残らない
* https://github.com/montsuqi/panda-samples/tree/master/dbaccess
    * glclient2で正しく動作すること
    * /tmp/panda_root以下にセッションディレクトリが残る