### PR TITLE
サーバ編集ダイアログでの設定編集を廃止

### DIFF
--- a/glclient/bootdialog.c
+++ b/glclient/bootdialog.c
@@ -88,18 +88,6 @@ static void edit_dialog_run(GtkWidget *parent, int n) {
   gtk_widget_show_all(table);
 
   component = bd_component_new();
-  gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))),
-                     component->basictable, TRUE, TRUE, 0);
-  gtk_widget_show_all(component->basictable);
-
-  gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))),
-                     component->ssltable, TRUE, TRUE, 0);
-  gtk_widget_show_all(component->ssltable);
-
-  gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))),
-                     component->othertable, TRUE, TRUE, 0);
-  gtk_widget_show_all(component->othertable);
-
   bd_component_set_value(component, n);
 
   /* run */


### PR DESCRIPTION
* サーバ編集ダイアログが縦に伸びていて1280x800の画面外に出るので、設定編集をダイアログからはずし、サーバ設定名のみ編集するよう修正
    * 設定はランチャー画面でサーバ設定を変更して行う
    * monsiajと同様のやり方
* 縦に長い
    * ![1.png](https://github.com/montsuqi/panda/wiki/images/20210326-1.png)
* サーバ名のみの編集
    * ![2.png](https://github.com/montsuqi/panda/wiki/images/20210326-2.png)
 
## 動作確認

* サーバ設定を新規作成して、ランチャーで設定編集できることを確認
* サーバ設定の編集ができることを確認
* サーバ設定の削除ができることを確認
* scan-buildのパスを確認