### PR TITLE
crtl->limitが0以下の場合、1に変更する

### DIFF
--- a/dblib/PostgreSQL.c
+++ b/dblib/PostgreSQL.c
@@ -1398,6 +1398,9 @@ static ValueStruct *_DBFETCH(DBG_Struct *dbg, DBCOMM_CTRL *ctrl,
 
   ret = NULL;
   ctrl->rcount = 0;
+  if (ctrl->limit <= 0) {
+    ctrl->limit = 1;
+  }
   if ((rec == NULL) || (rec->type != RECORD_DB)) {
     ctrl->rc = MCP_BAD_ARG;
   } else {


### PR DESCRIPTION
* 日レセ 5.2でctrl->limit = 0 を設定している箇所がある
    * 日レセ側の不具合?
* そもそもlimit = 0(FETCH 0 FROM CURSOR)は使用しないと考えられるので_FETCH内で1にしてしまう

## 動作確認

* https://github.com/montsuqi/panda-samples/tree/master/dbfetch で limit = 0 を指定しても limit = 1 で動作することを確認
* scan-buildのパスを確認 