### PR TITLE
APIの一時ディレクトリについて即時削除から3時間経過削除に変更

### DIFF
--- a/include/dirs.h
+++ b/include/dirs.h
@@ -36,4 +36,5 @@ GLOBAL char *PasswordFile;
 GLOBAL char *SesDir;
 GLOBAL char *D_Dir;
 GLOBAL char *TempDirRoot;
+GLOBAL char *ApiTempDirRoot;
 #endif

--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -96,6 +96,10 @@ static SessionData *NewSessionData(int type) {
   InitializeValue(data->sysdbval);
   data->count = 0;
   data->w.sp = 0;
+  /* 古い一時ディレクトリの削除 */
+  rm_r_old_depth(TempDirRoot,86400,1); /* TERM:1day */
+  rm_r_old_depth(ApiTempDirRoot,10800,1); /* API:3hour */
+  /* 一時ディレクトリ作成 */
   if (type == SESSION_TYPE_TERM) {
     snprintf(data->hdr->tempdir, SIZE_PATH, "%s/%s", TempDirRoot,
              data->hdr->uuid);
@@ -106,9 +110,6 @@ static SessionData *NewSessionData(int type) {
   if (!MakeDir(data->hdr->tempdir, 0700)) {
     Error("cannot make session tempdir %s", data->hdr->tempdir);
   }
-  /* 古いセッションデータの削除 */
-  rm_r_old_depth(TempDirRoot,86400,1); /* TERM:1day */
-  rm_r_old_depth(ApiTempDirRoot,10800,1); /* API:3hour */
   return (data);
 }
 

--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -140,8 +140,10 @@ static guint FreeWindowTable(char *name, void *data, void *dummy) {
 }
 
 static void FreeSessionData(SessionData *data) {
-  MessageLogPrintf("session end %s [%s@%s] %s", data->hdr->uuid,
-                   data->hdr->user, data->hdr->host, data->agent);
+  if (data->type == SESSION_TYPE_TERM) {
+    MessageLogPrintf("session end %s [%s@%s] %s", data->hdr->uuid,
+                     data->hdr->user, data->hdr->host, data->agent);
+  }
   if (data->linkdata != NULL) {
     FreeLBS(data->linkdata);
   }

--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -67,13 +67,13 @@ extern void TermEnqueue(TermNode *term, SessionData *data) {
   EnQueue(term->que, data);
 }
 
-static SessionData *NewSessionData(void) {
+static SessionData *NewSessionData(int type) {
   SessionData *data;
   uuid_t u;
 
   data = New(SessionData);
   memclear(data, sizeof(SessionData));
-  data->type = SESSION_TYPE_TERM;
+  data->type = type;
   data->status = SESSION_STATUS_NORMAL;
   data->hdr = New(MessageHeader);
   memclear(data->hdr, sizeof(MessageHeader));
@@ -96,11 +96,19 @@ static SessionData *NewSessionData(void) {
   InitializeValue(data->sysdbval);
   data->count = 0;
   data->w.sp = 0;
-  snprintf(data->hdr->tempdir, SIZE_PATH, "%s/%s", TempDirRoot,
-           data->hdr->uuid);
+  if (type == SESSION_TYPE_TERM) {
+    snprintf(data->hdr->tempdir, SIZE_PATH, "%s/%s", TempDirRoot,
+             data->hdr->uuid);
+  } else {
+    snprintf(data->hdr->tempdir, SIZE_PATH, "%s/%s", ApiTempDirRoot,
+             data->hdr->uuid);
+  }
   if (!MakeDir(data->hdr->tempdir, 0700)) {
     Error("cannot make session tempdir %s", data->hdr->tempdir);
   }
+  /* 古いセッションデータの削除 */
+  rm_r_old_depth(TempDirRoot,86400,1); /* TERM:1day */
+  rm_r_old_depth(ApiTempDirRoot,10800,1); /* API:3hour */
   return (data);
 }
 
@@ -132,15 +140,8 @@ static guint FreeWindowTable(char *name, void *data, void *dummy) {
 }
 
 static void FreeSessionData(SessionData *data) {
-  /* APIの場合は一時ディレクトリを削除 */
-  if (data->type == SESSION_TYPE_API) {
-    if (!rm_r(data->hdr->tempdir)) {
-      Error("cannot remove api session tempdir %s",data->hdr->tempdir);
-    }
-  } else {
-    MessageLogPrintf("session end %s [%s@%s] %s", data->hdr->uuid,
-                     data->hdr->user, data->hdr->host, data->agent);
-  }
+  MessageLogPrintf("session end %s [%s@%s] %s", data->hdr->uuid,
+                   data->hdr->user, data->hdr->host, data->agent);
   if (data->linkdata != NULL) {
     FreeLBS(data->linkdata);
   }
@@ -184,8 +185,6 @@ static void RegisterSession(SessionData *data) {
   ctrl->session = data;
   ctrl = ExecSessionCtrl(ctrl);
   FreeSessionCtrl(ctrl);
-  /* 古いセッションデータの削除 */
-  rm_r_old_depth(TempDirRoot,86400,1); /* 86400 = 1day */
 }
 
 static SessionData *LookupSession(const char *term) {
@@ -234,8 +233,7 @@ static SessionData *InitAPISession(const char *user, const char *wname,
   SessionData *data;
   LD_Node *ld;
 
-  data = NewSessionData();
-  data->type = SESSION_TYPE_API;
+  data = NewSessionData(SESSION_TYPE_API);
   strcpy(data->hdr->window, wname);
   strcpy(data->hdr->user, user);
   strcpy(data->hdr->host, host);
@@ -345,7 +343,7 @@ static void RPC_StartSession(TermNode *term, json_object *obj) {
     return;
   }
 
-  data = NewSessionData();
+  data = NewSessionData(SESSION_TYPE_TERM);
   data->linkdata = NewLinkData();
   data->term = term;
 

--- a/wfc/wfc.c
+++ b/wfc/wfc.c
@@ -289,6 +289,7 @@ static void SetDefault(void) {
   if (TempDirRoot == NULL) {
     TempDirRoot = "/tmp/panda_root/";
   }
+  ApiTempDirRoot = g_strdup_printf("%s/api/",TempDirRoot);
   MaxTransactionRetry = 0;
   ControlPort = NULL;
   SesNum = 0;


### PR DESCRIPTION
* https://github.com/montsuqi/panda/pull/288 にてAPIの一時ディレクトリを即時削除するようにしたが、問題があった
    * HAORIのAPIからバッチ処理を起動して帳票印刷するケースでは一時ディレクトリを即時削除すると正常動作しない
        * レスポンス返却時にはバッチ処理がまだ動作しているため
* クライアント接続とAPIの一時ディレクトリの親ディレクトリを分けた上で、APIの一時ディレクトリは3時間経過後に削除するよう修正
    * Term: <TempdirRoot>/*
    * API:<TempdirRoot>/api/* 
* 一時ディレクトリ削除のタイミングをRegisterSession()からNewSessionData()に変更
    * RegisterSession()はクライアント接続のタイミングでしかCallされないため
* scan-buildのパスを確認
* https://github.com/montsuqi/panda-samples/tree/master/xmlio2 での動作確認
    * API一時ディレクトリ削除300秒として、300秒経過後一時ディレクトリが削除されるのを確認
* 日レセパッケージを作成し、日レセクライアント、APIが動作することを確認  