### PR TITLE
一時ディレクトリのデフォルト削除時間の変更および環境変数での設定

### DIFF
--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -63,8 +63,8 @@
 #include "message.h"
 #include "debug.h"
 
-static long old_tempdir_rm_sec     = 86400; /* 1day  */
-static long old_api_tempdir_rm_sec = 10800; /* 3hour */
+static long old_tempdir_rm_sec     = 86400; /* 1day */
+static long old_api_tempdir_rm_sec = 86400; /* 1day */
 
 extern void TermEnqueue(TermNode *term, SessionData *data) {
   EnQueue(term->que, data);

--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -100,8 +100,8 @@ static SessionData *NewSessionData(int type) {
   data->count = 0;
   data->w.sp = 0;
   /* 古い一時ディレクトリの削除 */
-  rm_r_old_depth(TempDirRoot,old_tempdir_rm_sec,1); /* TERM:1day */
-  rm_r_old_depth(ApiTempDirRoot,old_api_tempdir_rm_sec,1); /* API:3hour */
+  rm_r_old_depth(TempDirRoot,old_tempdir_rm_sec,1);
+  rm_r_old_depth(ApiTempDirRoot,old_api_tempdir_rm_sec,1);
   /* 一時ディレクトリ作成 */
   if (type == SESSION_TYPE_TERM) {
     snprintf(data->hdr->tempdir, SIZE_PATH, "%s/%s", TempDirRoot,

--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -1100,7 +1100,7 @@ extern void InitTerm(void) {
       old_tempdir_rm_sec = 0;
     }
   }
-  if ((env = getenv("WFC_API_OLD_TEMPDIR_REMOVE_SEC")) != NULL) {
+  if ((env = getenv("WFC_OLD_API_TEMPDIR_REMOVE_SEC")) != NULL) {
     MessageLogPrintf("old_api_tempdir_rm_sec %ld -> %ld", 
       old_api_tempdir_rm_sec, atol(env));
     old_api_tempdir_rm_sec = atol(env);

--- a/wfc/termthread.c
+++ b/wfc/termthread.c
@@ -63,6 +63,9 @@
 #include "message.h"
 #include "debug.h"
 
+static long old_tempdir_rm_sec     = 86400; /* 1day  */
+static long old_api_tempdir_rm_sec = 10800; /* 3hour */
+
 extern void TermEnqueue(TermNode *term, SessionData *data) {
   EnQueue(term->que, data);
 }
@@ -97,8 +100,8 @@ static SessionData *NewSessionData(int type) {
   data->count = 0;
   data->w.sp = 0;
   /* 古い一時ディレクトリの削除 */
-  rm_r_old_depth(TempDirRoot,86400,1); /* TERM:1day */
-  rm_r_old_depth(ApiTempDirRoot,10800,1); /* API:3hour */
+  rm_r_old_depth(TempDirRoot,old_tempdir_rm_sec,1); /* TERM:1day */
+  rm_r_old_depth(ApiTempDirRoot,old_api_tempdir_rm_sec,1); /* API:3hour */
   /* 一時ディレクトリ作成 */
   if (type == SESSION_TYPE_TERM) {
     snprintf(data->hdr->tempdir, SIZE_PATH, "%s/%s", TempDirRoot,
@@ -1084,8 +1087,25 @@ extern int ConnectTerm(int _fhTerm) {
 }
 
 extern void InitTerm(void) {
+  char *env;
   RecParserInit();
   if (ThisEnv->linkrec != NULL) {
     InitializeValue(ThisEnv->linkrec->value);
+  }
+  if ((env = getenv("WFC_OLD_TEMPDIR_REMOVE_SEC")) != NULL) {
+    MessageLogPrintf("old_tempdir_rm_sec %ld -> %ld", 
+      old_tempdir_rm_sec, atol(env));
+    old_tempdir_rm_sec = atol(env);
+    if (old_tempdir_rm_sec < 0) {
+      old_tempdir_rm_sec = 0;
+    }
+  }
+  if ((env = getenv("WFC_API_OLD_TEMPDIR_REMOVE_SEC")) != NULL) {
+    MessageLogPrintf("old_api_tempdir_rm_sec %ld -> %ld", 
+      old_api_tempdir_rm_sec, atol(env));
+    old_api_tempdir_rm_sec = atol(env);
+    if (old_api_tempdir_rm_sec < 0) {
+      old_api_tempdir_rm_sec = 0;
+    }
   }
 }


### PR DESCRIPTION
* 日レセ端末とAPIの一時ディレクトリの削除時間を以下の環境変数で設定可能にした
    *  WFC_OLD_TEMPDIR_REMOVE_SEC
    *  WFC_OLD_API_TEMPDIR_REMOVE_SEC
* APIの一時ディレクトリのデフォルト削除時間を24時間に変更

### 動作確認

* 端末、APIいずれの環境変数も300に設定
    * syslogに環境変数設定のログがでること
    * 300秒経過した一時ディレクトリが削除されること
    * 日レセ端末、APIが動作すること
* scan-build確認