### PR TITLE
glserverがAPIレスポンス返却後abortしていた(json_object_putの重複実行のため)

### DIFF
--- a/glserver/http.c
+++ b/glserver/http.c
@@ -779,7 +779,6 @@ static gboolean APIHandler(HTTP_REQUEST *req) {
   res = WFCIO_JSONRPC(obj);
   json_object_put(obj);
   APISendResponse(req, res);
-  json_object_put(res);
   return TRUE;
 }
 

--- a/glserver/http.c
+++ b/glserver/http.c
@@ -766,7 +766,6 @@ static void APISendResponse(HTTP_REQUEST *req, json_object *obj) {
   } else {
     SendResponse(req, status, NULL, 0, NULL);
   }
-  json_object_put(obj);
 
   MessageLogPrintf("api %d /%s/%s/%s %s@%s %s", status, req->ld, req->window,
                    req->arguments, req->user, req->host, req->agent);
@@ -779,6 +778,7 @@ static gboolean APIHandler(HTTP_REQUEST *req) {
   res = WFCIO_JSONRPC(obj);
   json_object_put(obj);
   APISendResponse(req, res);
+  json_object_put(res);
   return TRUE;
 }
 


### PR DESCRIPTION
* glserverはforkモデルとなっていて、リクエスト処理の度にforkする
* リクエスト処理の子プロセスが、APIレスポンス返却後にabortしていたので見た目には正常動作しているように見えていた
* APISendResponse()でレスポンスのjson_objectをjson_object_put()しているのにも関わらず、APIHandlerで再度json_object_put()していた
* 修正後、gdb、valgrindでabort、エラーが発生しないことを確認

gdbのバックトレース
```
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f236ed6f859 in __GI_abort () at abort.c:79
#2  0x00007f236ed6f729 in __assert_fail_base (fmt=0x7f236ef05588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n",
    assertion=0x7f236f2d0052 "jso->_ref_count > 0", file=0x7f236f2d0044 "json_object.c", line=189, function=<optimized out>)
    at assert.c:92
#3  0x00007f236ed80f36 in __GI___assert_fail (assertion=0x7f236f2d0052 "jso->_ref_count > 0", file=0x7f236f2d0044 "json_object.c",
    line=189, function=0x7f236f2d02c0 "json_object_put") at assert.c:101
#4  0x00007f236f2c967a in json_object_put () from /lib/x86_64-linux-gnu/libjson-c.so.4
#5  0x0000000000405b0b in APIHandler (req=0x21e36b0) at http.c:782
#6  _HTTP_Method (req=0x21e36b0) at http.c:1179
#7  0x0000000000403f37 in HTTP_Method (fpComm=<optimized out>) at http.c:1249
#8  0x0000000000403d4a in ExecuteServer () at glserver.c:162
#9  0x0000000000403bc6 in main (argc=8, argv=0x7ffc5c024908) at glserver.c:237
```

glserverのログの警告
```
glserver: json_object.c:189: json_object_put: Assertion `jso->_ref_count > 0' failed.
```