### PR TITLE
Merge pull request #297 from montsuqi/fix-glserver-abort-APISendResponse

### DIFF
--- a/glserver/http.c
+++ b/glserver/http.c
@@ -766,7 +766,6 @@ static void APISendResponse(HTTP_REQUEST *req, json_object *obj) {
   } else {
     SendResponse(req, status, NULL, 0, NULL);
   }
-  json_object_put(obj);
 
   MessageLogPrintf("api %d /%s/%s/%s %s@%s %s", status, req->ld, req->window,
                    req->arguments, req->user, req->host, req->agent);


### PR DESCRIPTION
glserverがAPIレスポンス返却後abortしていた(json_object_putの重複実行のため)